### PR TITLE
refactor(featctl/export): refactor `export` options

### DIFF
--- a/featctl/cmd/export.go
+++ b/featctl/cmd/export.go
@@ -27,7 +27,7 @@ func init() {
 	flags := exportCmd.Flags()
 
 	flags.StringVarP(&exportOpt.Group, "group", "g", "", "feature group")
-	flags.StringArrayVarP(&exportOpt.Features, "name", "n", nil, "feature name")
+	flags.StringSliceVarP(&exportOpt.Features, "name", "n", nil, "feature name")
 	flags.StringVarP(&exportOpt.OutputFile, "output-file", "o", "", "output file")
 	_ = exportCmd.MarkFlagRequired("group")
 	_ = exportCmd.MarkFlagRequired("output-file")


### PR DESCRIPTION
Refactor `report` sub command with two changes:

1. always export field `entity_key`
2. use **options** instead of **args** to collect feature names.