### PR TITLE
refactor(database) replace obj DB with export func

### DIFF
--- a/featctl/pkg/query/query.go
+++ b/featctl/pkg/query/query.go
@@ -35,7 +35,7 @@ func Run(ctx context.Context, opt *Option) {
 	}
 }
 
-func queryFeatureAndPrintToStdout(ctx context.Context, db *sqlx.DB, opt *Option) error {
+func queryFeatureAndPrintToStdout(ctx context.Context, db database.DB, opt *Option) error {
 	entityTableMapFeatures, err := getEntityTableMapFeatures(ctx, db, opt)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func queryFeatureAndPrintToStdout(ctx context.Context, db *sqlx.DB, opt *Option)
 	return nil
 }
 
-func getEntityTableMapFeatures(ctx context.Context, db *sqlx.DB, opt *Option) (map[string][]string, error) {
+func getEntityTableMapFeatures(ctx context.Context, db database.DB, opt *Option) (map[string][]string, error) {
 	mp := make(map[string][]string)
 
 	if opt.Revision != "" {
@@ -75,7 +75,7 @@ func getEntityTableMapFeatures(ctx context.Context, db *sqlx.DB, opt *Option) (m
 	return mp, nil
 }
 
-func getEntityTable(ctx context.Context, db *sqlx.DB, group, featureName string) (string, error) {
+func getEntityTable(ctx context.Context, db database.DB, group, featureName string) (string, error) {
 	var revision string
 	err := db.QueryRowContext(ctx, `select fc.revision from feature_config as fc where fc.group = ? and fc.name = ?`, group, featureName).Scan(&revision)
 	switch {
@@ -88,7 +88,7 @@ func getEntityTable(ctx context.Context, db *sqlx.DB, group, featureName string)
 	}
 }
 
-func readOneTableToCsv(ctx context.Context, db *sqlx.DB, tableName string,
+func readOneTableToCsv(ctx context.Context, db database.DB, tableName string,
 	entityKeys []string, featureNames []string, w *csv.Writer, isFirstPrint bool) error {
 	// https://jmoiron.github.io/sqlx/#inQueries
 	sql, args, err := sqlx.In(

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -10,7 +10,7 @@ import (
 )
 
 type DB struct {
-	*sql.DB
+	*sqlx.DB
 }
 
 type Option struct {
@@ -21,7 +21,7 @@ type Option struct {
 	DbName string
 }
 
-func Open(option *Option) (*sqlx.DB, error) {
+func Open(option *Option) (DB, error) {
 	db, err := sqlx.Open(
 		"mysql",
 		fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
@@ -31,20 +31,7 @@ func Open(option *Option) (*sqlx.DB, error) {
 			option.Port,
 			option.DbName),
 	)
-	return db, err
-}
-
-func (db *DB) TableExists(ctx context.Context, table string) (bool, error) {
-	var result string
-	err := db.QueryRowContext(ctx, `show tables like ?`, table).Scan(&result)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	default:
-		return true, nil
-	}
+	return DB{db}, err
 }
 
 type Column struct {
@@ -64,4 +51,17 @@ func (db *DB) ColumnInfo(ctx context.Context, table string, column string) (Colu
 		return result, fmt.Errorf("column '%s' not found in table '%s'", column, table)
 	}
 	return result, err
+}
+
+func (db *DB) TableExists(ctx context.Context, table string) (bool, error) {
+	var result string
+	err := db.QueryRowContext(ctx, `show tables like ?`, table).Scan(&result)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, err
+	default:
+		return true, nil
+	}
 }

--- a/pkg/database/feature_config.go
+++ b/pkg/database/feature_config.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/jmoiron/sqlx"
 )
 
 type FeatureConfig struct {
@@ -21,7 +19,7 @@ type FeatureConfig struct {
 	ModifyTime     time.Time `db:"modify_time"`
 }
 
-func ListFeatureConfig(db *sqlx.DB) ([]FeatureConfig, error) {
+func ListFeatureConfig(db DB) ([]FeatureConfig, error) {
 	query := `SELECT * FROM feature_config`
 	features := make([]FeatureConfig, 0)
 	if err := db.Select(&features, query); err != nil {
@@ -30,7 +28,7 @@ func ListFeatureConfig(db *sqlx.DB) ([]FeatureConfig, error) {
 	return features, nil
 }
 
-func ListFeatureConfigByGroup(db *sqlx.DB, group string) ([]FeatureConfig, error) {
+func ListFeatureConfigByGroup(db DB, group string) ([]FeatureConfig, error) {
 	query := "SELECT * FROM feature_config AS fc WHERE fc.group = ?"
 	features := make([]FeatureConfig, 0)
 	if err := db.Select(&features, query, group); err != nil {
@@ -39,7 +37,7 @@ func ListFeatureConfigByGroup(db *sqlx.DB, group string) ([]FeatureConfig, error
 	return features, nil
 }
 
-func GetFeatureConfig(db *sqlx.DB, groupName, featureName string) (*FeatureConfig, error) {
+func GetFeatureConfig(db DB, groupName, featureName string) (*FeatureConfig, error) {
 	query := fmt.Sprintf(`SELECT * FROM feature_config AS fc WHERE fc.group = '%s' AND fc.name = '%s'`, groupName, featureName)
 	var feature FeatureConfig
 	if err := db.Select(&feature, query); err != nil {

--- a/pkg/database/group_revision.go
+++ b/pkg/database/group_revision.go
@@ -3,8 +3,6 @@ package database
 import (
 	"strings"
 	"time"
-
-	"github.com/jmoiron/sqlx"
 )
 
 type GroupRevision struct {
@@ -16,7 +14,7 @@ type GroupRevision struct {
 	ModifyTime  time.Time `db:"modify_time"`
 }
 
-func ListGroupRevisionByGroup(db *sqlx.DB, group string) ([]GroupRevision, error) {
+func ListGroupRevisionByGroup(db DB, group string) ([]GroupRevision, error) {
 	query := "SELECT * FROM feature_revision AS fr WHERE fr.group = ?"
 	revisions := make([]GroupRevision, 0)
 	if err := db.Select(&revisions, query, group); err != nil {


### PR DESCRIPTION
close https://github.com/onestore-ai/onestore/issues/38

### Description
This PR refactors database package, uses database.DB object replaces sqlx.DB to expoted

### Test

- [x] test subcommand `list revision` locally
- [x] test subcommand `quert` locally