### PR TITLE
refactor database.Open use *DB for return values

### DIFF
--- a/featctl/pkg/query/query.go
+++ b/featctl/pkg/query/query.go
@@ -35,7 +35,7 @@ func Run(ctx context.Context, opt *Option) {
 	}
 }
 
-func queryFeatureAndPrintToStdout(ctx context.Context, db database.DB, opt *Option) error {
+func queryFeatureAndPrintToStdout(ctx context.Context, db *database.DB, opt *Option) error {
 	entityTableMapFeatures, err := getEntityTableMapFeatures(ctx, db, opt)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func queryFeatureAndPrintToStdout(ctx context.Context, db database.DB, opt *Opti
 	return nil
 }
 
-func getEntityTableMapFeatures(ctx context.Context, db database.DB, opt *Option) (map[string][]string, error) {
+func getEntityTableMapFeatures(ctx context.Context, db *database.DB, opt *Option) (map[string][]string, error) {
 	mp := make(map[string][]string)
 
 	if opt.Revision != "" {
@@ -75,7 +75,7 @@ func getEntityTableMapFeatures(ctx context.Context, db database.DB, opt *Option)
 	return mp, nil
 }
 
-func getEntityTable(ctx context.Context, db database.DB, group, featureName string) (string, error) {
+func getEntityTable(ctx context.Context, db *database.DB, group, featureName string) (string, error) {
 	var revision string
 	err := db.QueryRowContext(ctx, `select fc.revision from feature_config as fc where fc.group = ? and fc.name = ?`, group, featureName).Scan(&revision)
 	switch {
@@ -88,7 +88,7 @@ func getEntityTable(ctx context.Context, db database.DB, group, featureName stri
 	}
 }
 
-func readOneTableToCsv(ctx context.Context, db database.DB, tableName string,
+func readOneTableToCsv(ctx context.Context, db *database.DB, tableName string,
 	entityKeys []string, featureNames []string, w *csv.Writer, isFirstPrint bool) error {
 	// https://jmoiron.github.io/sqlx/#inQueries
 	sql, args, err := sqlx.In(

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -21,7 +21,7 @@ type Option struct {
 	DbName string
 }
 
-func Open(option *Option) (DB, error) {
+func Open(option *Option) (*DB, error) {
 	db, err := sqlx.Open(
 		"mysql",
 		fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
@@ -31,7 +31,7 @@ func Open(option *Option) (DB, error) {
 			option.Port,
 			option.DbName),
 	)
-	return DB{db}, err
+	return &DB{db}, err
 }
 
 type Column struct {

--- a/pkg/database/feature_config.go
+++ b/pkg/database/feature_config.go
@@ -19,7 +19,7 @@ type FeatureConfig struct {
 	ModifyTime     time.Time `db:"modify_time"`
 }
 
-func ListFeatureConfig(db DB) ([]FeatureConfig, error) {
+func ListFeatureConfig(db *DB) ([]FeatureConfig, error) {
 	query := `SELECT * FROM feature_config`
 	features := make([]FeatureConfig, 0)
 	if err := db.Select(&features, query); err != nil {
@@ -28,7 +28,7 @@ func ListFeatureConfig(db DB) ([]FeatureConfig, error) {
 	return features, nil
 }
 
-func ListFeatureConfigByGroup(db DB, group string) ([]FeatureConfig, error) {
+func ListFeatureConfigByGroup(db *DB, group string) ([]FeatureConfig, error) {
 	query := "SELECT * FROM feature_config AS fc WHERE fc.group = ?"
 	features := make([]FeatureConfig, 0)
 	if err := db.Select(&features, query, group); err != nil {
@@ -37,7 +37,7 @@ func ListFeatureConfigByGroup(db DB, group string) ([]FeatureConfig, error) {
 	return features, nil
 }
 
-func GetFeatureConfig(db DB, groupName, featureName string) (*FeatureConfig, error) {
+func GetFeatureConfig(db *DB, groupName, featureName string) (*FeatureConfig, error) {
 	query := fmt.Sprintf(`SELECT * FROM feature_config AS fc WHERE fc.group = '%s' AND fc.name = '%s'`, groupName, featureName)
 	var feature FeatureConfig
 	if err := db.Select(&feature, query); err != nil {

--- a/pkg/database/group_revision.go
+++ b/pkg/database/group_revision.go
@@ -14,7 +14,7 @@ type GroupRevision struct {
 	ModifyTime  time.Time `db:"modify_time"`
 }
 
-func ListGroupRevisionByGroup(db DB, group string) ([]GroupRevision, error) {
+func ListGroupRevisionByGroup(db *DB, group string) ([]GroupRevision, error) {
 	query := "SELECT * FROM feature_revision AS fr WHERE fr.group = ?"
 	revisions := make([]GroupRevision, 0)
 	if err := db.Select(&revisions, query, group); err != nil {


### PR DESCRIPTION
### Description

The database package exports objects `DB` from value types to pointer types, which is more in line with the go programming specification.

This is some advice from go on how to choose value receiver and pointer receiver:

https://github.com/golang/go/wiki/CodeReviewComments#receiver-type

### Test

- [x] run `integration-test` locally