### PR TITLE
refactor(database) add context for per query method

### DIFF
--- a/featctl/pkg/list_feature/list_feature.go
+++ b/featctl/pkg/list_feature/list_feature.go
@@ -23,12 +23,12 @@ func ListFeature(ctx context.Context, option *Option) {
 
 	var features []database.FeatureConfig
 	if option.Group == "" {
-		features, err = database.ListFeatureConfig(db)
+		features, err = database.ListFeatureConfig(ctx, db)
 		if err != nil {
 			log.Fatalf("failed listing feature configs: %v", err)
 		}
 	} else {
-		features, err = database.ListFeatureConfigByGroup(db, option.Group)
+		features, err = database.ListFeatureConfigByGroup(ctx, db, option.Group)
 		if err != nil {
 			log.Fatalf("failed listing feature configs in group %s: %v", option.Group, err)
 		}

--- a/featctl/pkg/list_revision/list_revision.go
+++ b/featctl/pkg/list_revision/list_revision.go
@@ -21,7 +21,7 @@ func ListRevision(ctx context.Context, option *Option) {
 	}
 	defer db.Close()
 
-	revisions, err := database.ListGroupRevisionByGroup(db, option.Group)
+	revisions, err := database.ListGroupRevisionByGroup(ctx, db, option.Group)
 	if err != nil {
 		log.Fatalf("failed listing revisions for group %s: %v", option.Group, err)
 	}

--- a/pkg/database/feature_config.go
+++ b/pkg/database/feature_config.go
@@ -20,19 +20,19 @@ type FeatureConfig struct {
 	ModifyTime     time.Time `db:"modify_time"`
 }
 
-func ListFeatureConfig(db *DB) ([]FeatureConfig, error) {
+func ListFeatureConfig(ctx context.Context, db *DB) ([]FeatureConfig, error) {
 	query := `SELECT * FROM feature_config`
 	features := make([]FeatureConfig, 0)
-	if err := db.Select(&features, query); err != nil {
+	if err := db.SelectContext(ctx, &features, query); err != nil {
 		return nil, err
 	}
 	return features, nil
 }
 
-func ListFeatureConfigByGroup(db *DB, group string) ([]FeatureConfig, error) {
+func ListFeatureConfigByGroup(ctx context.Context, db *DB, group string) ([]FeatureConfig, error) {
 	query := "SELECT * FROM feature_config AS fc WHERE fc.group = ?"
 	features := make([]FeatureConfig, 0)
-	if err := db.Select(&features, query, group); err != nil {
+	if err := db.SelectContext(ctx, &features, query, group); err != nil {
 		return nil, err
 	}
 	return features, nil

--- a/pkg/database/group_revision.go
+++ b/pkg/database/group_revision.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"strings"
 	"time"
 )
@@ -14,10 +15,10 @@ type GroupRevision struct {
 	ModifyTime  time.Time `db:"modify_time"`
 }
 
-func ListGroupRevisionByGroup(db *DB, group string) ([]GroupRevision, error) {
+func ListGroupRevisionByGroup(ctx context.Context, db *DB, group string) ([]GroupRevision, error) {
 	query := "SELECT * FROM feature_revision AS fr WHERE fr.group = ?"
 	revisions := make([]GroupRevision, 0)
-	if err := db.Select(&revisions, query, group); err != nil {
+	if err := db.SelectContext(ctx, &revisions, query, group); err != nil {
 		return nil, err
 	}
 	return revisions, nil


### PR DESCRIPTION
### Description

add parameter `ctx context.Context` for per query method, which is used for various controls on io operations, such as timeout management

### Test

- [x] run 'make integeration` locally