### PR TITLE
feat: make featctl support both tidb and mysql

### DIFF
--- a/featctl/test/test_list_feature.sh
+++ b/featctl/test/test_list_feature.sh
@@ -13,4 +13,4 @@ model,device,v1,disabled,batch,varchar(32),device model name,3,2021-09-27T08:24:
 '
 actual=$(featctl list feature)
 ignore_time() { cut -d ',' -f 1-8 <<<"$1"; }
-assert_eq "$case" "$(ignore_time "$expected")" "$(ignore_time "$actual")"
+assert_eq "$case" "$(ignore_time "$expected" | sort)" "$(ignore_time "$actual" | sort)"

--- a/featctl/test/test_update_feature.sh
+++ b/featctl/test/test_update_feature.sh
@@ -17,4 +17,4 @@ price,v2
 model,v1
 '
 actual=$(featctl list feature | cut -d ',' -f 1,3)
-assert_eq "$case" "$expected" "$actual"
+assert_eq "$case" "$(sort <<<"$expected")" "$(sort <<< "$actual")"

--- a/featctl/test/util.sh
+++ b/featctl/test/util.sh
@@ -50,7 +50,6 @@ assert_eq() {
 import_sample() {
     local revision=$1
     info "import sample data $revision"
-    trap 'command rm -rf -- lightning.* *.tmp' EXIT INT TERM HUP
 
     featctl import \
     --group device \

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -49,7 +49,7 @@ type Column struct {
 
 func (db *DB) ColumnInfo(ctx context.Context, table string, column string) (Column, error) {
 	var result Column
-	err := db.QueryRowContext(ctx, fmt.Sprintf("show columns from `%s` like ?", table), column).
+	err := db.QueryRowContext(ctx, fmt.Sprintf("show columns from `%s` like '%s'", table, column)).
 		Scan(&result.Field, &result.Type, &result.Null, &result.Key, &result.Default, &result.Extra)
 	if err == sql.ErrNoRows {
 		return result, fmt.Errorf("column '%s' not found in table '%s'", column, table)
@@ -59,7 +59,7 @@ func (db *DB) ColumnInfo(ctx context.Context, table string, column string) (Colu
 
 func (db *DB) TableExists(ctx context.Context, table string) (bool, error) {
 	var result string
-	err := db.GetContext(ctx, &result, `show tables like ?`, table)
+	err := db.GetContext(ctx, &result, fmt.Sprintf(`show tables like '%s'`, table))
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil


### PR DESCRIPTION
Now we can use mysql 5.7 as playground:

```
docker run --rm -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -p 4000:3306 mysql:5.7
```