### PR TITLE
refactor(group): rename Group to featureGroup

### DIFF
--- a/internal/database/feature_group.go
+++ b/internal/database/feature_group.go
@@ -6,14 +6,14 @@ import (
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (db *DB) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) error {
+func (db *DB) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) error {
 	_, err := db.ExecContext(ctx,
 		"insert into feature_group(name, entity_name, category, description) values(?, ?, ?, ?)",
 		opt.Name, opt.EntityName, opt.Category, opt.Description)
 	return err
 }
 
-func (db *DB) GetGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
+func (db *DB) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
 	var group types.FeatureGroup
 	query := `SELECT * FROM feature_group WHERE name = ?`
 	if err := db.GetContext(ctx, &group, query, groupName); err != nil {

--- a/pkg/onestore/feature.go
+++ b/pkg/onestore/feature.go
@@ -30,7 +30,7 @@ func (s *OneStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt
 }
 
 func (s *OneStore) CreateBatchFeature(ctx context.Context, opt types.CreateBatchFeatureOpt) (*types.Feature, error) {
-	group, err := s.db.GetGroup(ctx, opt.GroupName)
+	group, err := s.db.GetFeatureGroup(ctx, opt.GroupName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/onestore/feature_group.go
+++ b/pkg/onestore/feature_group.go
@@ -6,10 +6,10 @@ import (
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (s *OneStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) error {
-	return s.db.CreateGroup(ctx, opt)
+func (s *OneStore) CreateGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) error {
+	return s.db.CreateFeatureGroup(ctx, opt)
 }
 
 func (s *OneStore) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
-	return s.db.GetGroup(ctx, groupName)
+	return s.db.GetFeatureGroup(ctx, groupName)
 }

--- a/pkg/onestore/types/options.go
+++ b/pkg/onestore/types/options.go
@@ -18,7 +18,7 @@ type UpdateFeatureOpt struct {
 	NewDescription string
 }
 
-type CreateGroupOpt struct {
+type CreateFeatureGroupOpt struct {
 	Name        string
 	EntityName  string
 	Category    string


### PR DESCRIPTION
#### Updated
1. `types.CreateGroupOpt` -> `types.CreateFeatureGroupOpt`
2. `database.DB.CreateGroup()` -> `database.DB.CreateFeatureGroup()`
3. `database.DB.GetGroup()` -> `database.DB.GetFeatureGroup()`
4. `onestore.Onestore.CreateGroup()` -> `onestore.Onestore.CreateFeatureGroup()`