### PR TITLE
refactor: refactor create-feature-group api

### DIFF
--- a/featctl/cmd/register_group.go
+++ b/featctl/cmd/register_group.go
@@ -18,7 +18,7 @@ var registerGroupCmd = &cobra.Command{
 		registerGroupOpt.Name = args[0]
 		ctx := context.Background()
 		onestore := mustOpenOneStore(ctx, oneStoreOpt)
-		if err := onestore.CreateFeatureGroup(ctx, registerGroupOpt); err != nil {
+		if _, err := onestore.CreateFeatureGroup(ctx, registerGroupOpt); err != nil {
 			log.Fatalf("failed registering new group: %v\n", err)
 		}
 	},
@@ -31,9 +31,6 @@ func init() {
 
 	flags.StringVarP(&registerGroupOpt.EntityName, "entity", "e", "", "entity name")
 	_ = registerGroupCmd.MarkFlagRequired("entity")
-
-	flags.StringVar(&registerGroupOpt.Category, "category", "", "group category")
-	_ = registerGroupCmd.MarkFlagRequired("category")
 
 	flags.StringVarP(&registerGroupOpt.Description, "description", "d", "", "group description")
 }

--- a/internal/database/feature_group.go
+++ b/internal/database/feature_group.go
@@ -9,10 +9,9 @@ import (
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (db *DB) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) error {
-	_, err := db.ExecContext(ctx,
-		"insert into feature_group(name, entity_name, category, description) values(?, ?, ?, ?)",
-		opt.Name, opt.EntityName, opt.Category, opt.Description)
+func (db *DB) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt, category string) error {
+	query := "insert into feature_group(name, entity_name, category, description) values(?, ?, ?, ?)"
+	_, err := db.ExecContext(ctx, query, opt.Name, opt.EntityName, category, opt.Description)
 	return err
 }
 

--- a/pkg/onestore/feature_group.go
+++ b/pkg/onestore/feature_group.go
@@ -6,8 +6,11 @@ import (
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (s *OneStore) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) error {
-	return s.db.CreateFeatureGroup(ctx, opt)
+func (s *OneStore) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) (*types.FeatureGroup, error) {
+	if err := s.db.CreateFeatureGroup(ctx, opt, types.BatchFeatureCategory); err != nil {
+		return nil, err
+	}
+	return s.GetFeatureGroup(ctx, opt.Name)
 }
 
 func (s *OneStore) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {

--- a/pkg/onestore/types/options.go
+++ b/pkg/onestore/types/options.go
@@ -34,7 +34,6 @@ type CreateEntityOpt struct {
 type CreateFeatureGroupOpt struct {
 	Name        string
 	EntityName  string
-	Category    string
 	Description string
 }
 


### PR DESCRIPTION
Remove `category` option from `CreateFeatureGroupOpt` and return the new `FeatureGroup` instance after creating.