### PR TITLE
fix(featctl): fix `list feature` option parsing

### DIFF
--- a/featctl/cmd/list_feature.go
+++ b/featctl/cmd/list_feature.go
@@ -35,6 +35,6 @@ func init() {
 
 	flags := listFeatureCmd.Flags()
 
-	flags.StringVarP(listFeatureOpt.EntityName, "entity", "e", "", "entity")
-	flags.StringVarP(listFeatureOpt.GroupName, "group", "g", "", "feature group")
+	listFeatureOpt.EntityName = flags.StringP("entity", "e", "", "entity")
+	listFeatureOpt.GroupName = flags.StringP("group", "g", "", "feature group")
 }


### PR DESCRIPTION
Nil pointer can't be use in `XXXVarP` or `XXXVar` api:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x53e229]

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).StringVarP(0x1, 0x0, {0x7ea182, 0xc00011bd00}, {0x7e92e7, 0xae53a0}, {0x0, 0x1}, {0x7ea182, 0x6})
        /home/wenxuan/.go/pkg/mod/github.com/spf13/pflag@v1.0.5/string.go:42 +0x29
github.com/onestore-ai/onestore/featctl/cmd.init.8()
        /home/wenxuan/develop/onestore.ai/onestore/featctl/cmd/list_feature.go:38 +0x8f
```