### PR TITLE
refactor: re-organize onestore options

### DIFF
--- a/internal/database/metadata/database.go
+++ b/internal/database/metadata/database.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/onestore-ai/onestore/internal/database/metadata/postgres"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -17,7 +18,7 @@ type Store interface {
 	UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error
 
 	// feature
-	CreateFeature(ctx context.Context, opt types.DBCreateFeatureOpt) error
+	CreateFeature(ctx context.Context, opt dbtypes.CreateFeatureOpt) error
 	GetFeature(ctx context.Context, featureName string) (*types.Feature, error)
 	ListFeature(ctx context.Context, groupName *string) ([]*types.Feature, error)
 	UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error
@@ -39,7 +40,7 @@ type Store interface {
 	GetRevision(ctx context.Context, groupName string, revision int64) (*types.Revision, error)
 	GetRevisionsByDataTables(ctx context.Context, dataTables []string) ([]*types.Revision, error)
 	BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error)
-	InsertRevision(ctx context.Context, opt types.InsertRevisionOpt) error
+	InsertRevision(ctx context.Context, opt dbtypes.InsertRevisionOpt) error
 
 	io.Closer
 }

--- a/internal/database/metadata/postgres/feature.go
+++ b/internal/database/metadata/postgres/feature.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/onestore-ai/onestore/internal/database"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -29,7 +30,7 @@ func (db *DB) validateDataType(ctx context.Context, dataType string) error {
 	})
 }
 
-func (db *DB) CreateFeature(ctx context.Context, opt types.DBCreateFeatureOpt) error {
+func (db *DB) CreateFeature(ctx context.Context, opt dbtypes.CreateFeatureOpt) error {
 	if err := db.validateDataType(ctx, opt.DBValueType); err != nil {
 		return fmt.Errorf("err when validating value_type input, details: %s", err.Error())
 	}

--- a/internal/database/metadata/postgres/revision.go
+++ b/internal/database/metadata/postgres/revision.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/jmoiron/sqlx"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -48,7 +49,7 @@ func (db *DB) GetRevisionsByDataTables(ctx context.Context, dataTables []string)
 	return revisions, nil
 }
 
-func (db *DB) InsertRevision(ctx context.Context, opt types.InsertRevisionOpt) error {
+func (db *DB) InsertRevision(ctx context.Context, opt dbtypes.InsertRevisionOpt) error {
 	query := "INSERT INTO feature_group_revision(group_name, revision, data_table, description) VALUES ($1, $2, $3, $4)"
 	_, err := db.ExecContext(ctx, query, opt.GroupName, opt.Revision, opt.DataTable, opt.Description)
 	return err

--- a/internal/database/offline/database.go
+++ b/internal/database/offline/database.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/onestore-ai/onestore/internal/database"
 	"github.com/onestore-ai/onestore/internal/database/offline/postgres"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
 type Store interface {
 	GetPointInTimeFeatureValues(ctx context.Context, entity *types.Entity, revisionRanges []*types.RevisionRange, features []*types.RichFeature, entityRows []types.EntityRow) (dataMap map[string]database.RowMap, err error)
-	GetFeatureValuesStream(ctx context.Context, opt types.GetFeatureValuesStreamOpt) (<-chan *types.RawFeatureValueRecord, error)
+	GetFeatureValuesStream(ctx context.Context, opt dbtypes.GetFeatureValuesStreamOpt) (<-chan *types.RawFeatureValueRecord, error)
 	ImportBatchFeatures(ctx context.Context, opt types.ImportBatchFeaturesOpt, entity *types.Entity, features []*types.Feature, header []string) (int64, string, error)
 
 	ValueTypeTag(dbValueType string) (string, error)

--- a/internal/database/offline/postgres/stream.go
+++ b/internal/database/offline/postgres/stream.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (db *DB) GetFeatureValuesStream(ctx context.Context, opt types.GetFeatureValuesStreamOpt) (<-chan *types.RawFeatureValueRecord, error) {
+func (db *DB) GetFeatureValuesStream(ctx context.Context, opt dbtypes.GetFeatureValuesStreamOpt) (<-chan *types.RawFeatureValueRecord, error) {
 	fields := append([]string{opt.EntityName}, opt.FeatureNames...)
 	query := fmt.Sprintf("select %s from %s", strings.Join(fields, ","), opt.DataTable)
 	if opt.Limit != nil {

--- a/internal/database/online/database.go
+++ b/internal/database/online/database.go
@@ -8,12 +8,13 @@ import (
 	"github.com/onestore-ai/onestore/internal/database"
 	"github.com/onestore-ai/onestore/internal/database/online/postgres"
 	"github.com/onestore-ai/onestore/internal/database/online/redis"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
 type Store interface {
 	GetFeatureValues(ctx context.Context, opt types.GetFeatureValuesOpt) (database.RowMap, error)
-	MultiGetOnlineFeatureValues(ctx context.Context, opt types.DBMultiGetOnlineFeatureValuesOpt) (map[string]database.RowMap, error)
+	MultiGetOnlineFeatureValues(ctx context.Context, opt dbtypes.MultiGetOnlineFeatureValuesOpt) (map[string]database.RowMap, error)
 	SinkFeatureValuesStream(ctx context.Context, stream <-chan *types.RawFeatureValueRecord, features []*types.Feature, revision *types.Revision, entity *types.Entity) error
 	DeprecateFeatureValues(ctx context.Context, tableName string) error
 	io.Closer

--- a/internal/database/online/postgres/feature_value.go
+++ b/internal/database/online/postgres/feature_value.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/onestore-ai/onestore/internal/database"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 	"github.com/spf13/cast"
 )
@@ -26,7 +27,7 @@ func (db *DB) GetFeatureValues(ctx context.Context, opt types.GetFeatureValuesOp
 }
 
 // response: map[entity_key]map[feature_name]feature_value
-func (db *DB) MultiGetOnlineFeatureValues(ctx context.Context, opt types.DBMultiGetOnlineFeatureValuesOpt) (map[string]database.RowMap, error) {
+func (db *DB) MultiGetOnlineFeatureValues(ctx context.Context, opt dbtypes.MultiGetOnlineFeatureValuesOpt) (map[string]database.RowMap, error) {
 	featureNames := []string{}
 	for _, f := range opt.Features {
 		featureNames = append(featureNames, f.Name)

--- a/internal/database/online/redis/feature_value.go
+++ b/internal/database/online/redis/feature_value.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/onestore-ai/onestore/internal/database"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -39,7 +40,7 @@ func (db *DB) GetFeatureValues(ctx context.Context, opt types.GetFeatureValuesOp
 }
 
 // response: map[entity_key]map[feature_name]feature_value
-func (db *DB) MultiGetOnlineFeatureValues(ctx context.Context, opt types.DBMultiGetOnlineFeatureValuesOpt) (map[string]database.RowMap, error) {
+func (db *DB) MultiGetOnlineFeatureValues(ctx context.Context, opt dbtypes.MultiGetOnlineFeatureValuesOpt) (map[string]database.RowMap, error) {
 	res := make(map[string]database.RowMap)
 	for _, entityKey := range opt.EntityKeys {
 		rowMap, err := db.GetFeatureValues(ctx, types.GetFeatureValuesOpt{

--- a/internal/database/types/options.go
+++ b/internal/database/types/options.go
@@ -1,0 +1,30 @@
+package options
+
+import "github.com/onestore-ai/onestore/pkg/onestore/types"
+
+type MultiGetOnlineFeatureValuesOpt struct {
+	DataTable  string
+	EntityName string
+	RevisionId int32
+	EntityKeys []string
+	Features   []*types.Feature
+}
+
+type CreateFeatureOpt struct {
+	types.CreateFeatureOpt
+	ValueType string
+}
+
+type GetFeatureValuesStreamOpt struct {
+	DataTable    string
+	EntityName   string
+	FeatureNames []string
+	Limit        *uint64
+}
+
+type InsertRevisionOpt struct {
+	Revision    int64
+	GroupName   string
+	DataTable   string
+	Description string
+}

--- a/pkg/onestore/export.go
+++ b/pkg/onestore/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -48,7 +49,7 @@ func (s *OneStore) ExportFeatureValues(ctx context.Context, opt types.ExportFeat
 		}
 	}
 
-	stream, err := s.offline.GetFeatureValuesStream(ctx, types.GetFeatureValuesStreamOpt{
+	stream, err := s.offline.GetFeatureValuesStream(ctx, dbtypes.GetFeatureValuesStreamOpt{
 		DataTable:    dataTable,
 		EntityName:   group.EntityName,
 		FeatureNames: featureNames,

--- a/pkg/onestore/feature.go
+++ b/pkg/onestore/feature.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -44,7 +45,7 @@ func (s *OneStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatu
 	if group.Category != types.BatchFeatureCategory {
 		return nil, fmt.Errorf("expected batch feature group, got %s feature group", group.Category)
 	}
-	if err := s.metadata.CreateFeature(ctx, types.DBCreateFeatureOpt{
+	if err := s.metadata.CreateFeature(ctx, dbtypes.CreateFeatureOpt{
 		CreateFeatureOpt: opt,
 		ValueType:        valueType,
 	}); err != nil {

--- a/pkg/onestore/import.go
+++ b/pkg/onestore/import.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -92,7 +93,7 @@ func (s *OneStore) ImportBatchFeatures(ctx context.Context, opt types.ImportBatc
 		return err
 	}
 
-	return s.metadata.InsertRevision(ctx, types.InsertRevisionOpt{
+	return s.metadata.InsertRevision(ctx, dbtypes.InsertRevisionOpt{
 		Revision:    revision,
 		GroupName:   opt.GroupName,
 		DataTable:   dataTable,

--- a/pkg/onestore/materialize.go
+++ b/pkg/onestore/materialize.go
@@ -3,6 +3,7 @@ package onestore
 import (
 	"context"
 
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -32,7 +33,7 @@ func (s *OneStore) Materialize(ctx context.Context, opt types.MaterializeOpt) er
 		return err
 	}
 
-	stream, err := s.offline.GetFeatureValuesStream(ctx, types.GetFeatureValuesStreamOpt{
+	stream, err := s.offline.GetFeatureValuesStream(ctx, dbtypes.GetFeatureValuesStreamOpt{
 		DataTable:    revision.DataTable,
 		EntityName:   group.EntityName,
 		FeatureNames: featureNames,

--- a/pkg/onestore/online_feature_value.go
+++ b/pkg/onestore/online_feature_value.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/onestore-ai/onestore/internal/database"
+	dbtypes "github.com/onestore-ai/onestore/internal/database/types"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
@@ -97,7 +98,7 @@ func (s *OneStore) getFeatureValueMap(ctx context.Context, entityKeys []string, 
 			continue
 		}
 
-		featureValues, err := s.online.MultiGetOnlineFeatureValues(ctx, types.DBMultiGetOnlineFeatureValuesOpt{
+		featureValues, err := s.online.MultiGetOnlineFeatureValues(ctx, dbtypes.MultiGetOnlineFeatureValuesOpt{
 			DataTable:  dataTable,
 			EntityName: entityName,
 			RevisionId: revisionId,

--- a/pkg/onestore/types/options.go
+++ b/pkg/onestore/types/options.go
@@ -34,11 +34,6 @@ type CreateFeatureOpt struct {
 	Description string
 }
 
-type DBCreateFeatureOpt struct {
-	CreateFeatureOpt
-	ValueType string
-}
-
 type ListFeatureOpt struct {
 	EntityName *string
 	GroupName  *string
@@ -60,8 +55,6 @@ type CreateFeatureGroupOpt struct {
 	EntityName  string
 	Description string
 }
-
-type WalkFeatureValuesFunc = func(header []string, key string, values []interface{}) error
 
 type ExportFeatureValuesOpt struct {
 	GroupName     string
@@ -91,11 +84,6 @@ type MultiGetOnlineFeatureValuesOpt struct {
 	EntityKeys   []string
 }
 
-type EntityRow struct {
-	EntityKey string `db:"entity_key"`
-	UnixTime  int64  `db:"unix_time"`
-}
-
 type GetHistoricalFeatureValuesOpt struct {
 	FeatureNames []string
 	EntityRows   []EntityRow
@@ -116,32 +104,10 @@ type MaterializeOpt struct {
 	GroupRevision int64
 }
 
-type GetFeatureValuesStreamOpt struct {
-	DataTable    string
-	EntityName   string
-	FeatureNames []string
-	Limit        *uint64
-}
-
-type InsertRevisionOpt struct {
-	Revision    int64
-	GroupName   string
-	DataTable   string
-	Description string
-}
-
 type GetFeatureValuesOpt struct {
 	DataTable  string
 	EntityName string
 	RevisionId int32
 	EntityKey  string
-	Features   []*Feature
-}
-
-type DBMultiGetOnlineFeatureValuesOpt struct {
-	DataTable  string
-	EntityName string
-	RevisionId int32
-	EntityKeys []string
 	Features   []*Feature
 }

--- a/pkg/onestore/types/types.go
+++ b/pkg/onestore/types/types.go
@@ -192,3 +192,8 @@ type RawFeatureValueRecord struct {
 	Record []interface{}
 	Error  error
 }
+
+type EntityRow struct {
+	EntityKey string `db:"entity_key"`
+	UnixTime  int64  `db:"unix_time"`
+}


### PR DESCRIPTION
1. Remove outdated types
2. Move internal database options into `internal/database/types`