### PR TITLE
refactor: modify GetPointInTimeFeatureValues signature

### DIFF
--- a/internal/database/offline/database.go
+++ b/internal/database/offline/database.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Store interface {
-	GetPointInTimeFeatureValues(ctx context.Context, entity *types.Entity, revisionRanges []*types.RevisionRange, features []*types.RichFeature, entityRows []types.EntityRow) (dataMap map[string]database.RowMap, err error)
+	GetPointInTimeFeatureValues(ctx context.Context, entity *types.Entity, entityRows []types.EntityRow, revisionRanges []*types.RevisionRange, features []*types.RichFeature) (dataMap map[string]database.RowMap, err error)
 	GetFeatureValuesStream(ctx context.Context, opt dbtypes.GetFeatureValuesStreamOpt) (<-chan *types.RawFeatureValueRecord, error)
 	ImportBatchFeatures(ctx context.Context, opt types.ImportBatchFeaturesOpt, entity *types.Entity, features []*types.Feature, header []string) (int64, string, error)
 

--- a/internal/database/offline/postgres/feature_value.go
+++ b/internal/database/offline/postgres/feature_value.go
@@ -12,8 +12,8 @@ import (
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (db *DB) GetPointInTimeFeatureValues(ctx context.Context, entity *types.Entity,
-	revisionRanges []*types.RevisionRange, features []*types.RichFeature, entityRows []types.EntityRow) (dataMap map[string]database.RowMap, err error) {
+func (db *DB) GetPointInTimeFeatureValues(ctx context.Context, entity *types.Entity, entityRows []types.EntityRow,
+	revisionRanges []*types.RevisionRange, features []*types.RichFeature) (dataMap map[string]database.RowMap, err error) {
 	if len(features) == 0 {
 		return make(map[string]database.RowMap), nil
 	}

--- a/pkg/onestore/offline_feature_value.go
+++ b/pkg/onestore/offline_feature_value.go
@@ -39,7 +39,7 @@ func (s *OneStore) GetHistoricalFeatureValues(ctx context.Context, opt types.Get
 		if err != nil {
 			return nil, err
 		}
-		featureValues, err := s.offline.GetPointInTimeFeatureValues(ctx, entity, revisionRanges, richFeatures, opt.EntityRows)
+		featureValues, err := s.offline.GetPointInTimeFeatureValues(ctx, entity, opt.EntityRows, revisionRanges, richFeatures)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
So that `entity` and `entityRows` stay closer