### PR TITLE
refactor(metastore): modify the parameter definition of the method CreateFeatureGroup

### DIFF
--- a/internal/database/metadata/database.go
+++ b/internal/database/metadata/database.go
@@ -26,7 +26,7 @@ type Store interface {
 	ListRichFeature(ctx context.Context, opt types.ListFeatureOpt) ([]*types.RichFeature, error)
 
 	// feature group
-	CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt, category string) error
+	CreateFeatureGroup(ctx context.Context, opt CreateFeatureGroupOpt) error
 	GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error)
 	ListFeatureGroup(ctx context.Context, entityName *string) ([]*types.FeatureGroup, error)
 	UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) error

--- a/internal/database/metadata/postgres/database_test.go
+++ b/internal/database/metadata/postgres/database_test.go
@@ -164,11 +164,14 @@ func TestFeature(t *testing.T) {
 		Description: "description",
 	}))
 
-	assert.Nil(t, store.CreateFeatureGroup(context.Background(), types.CreateFeatureGroupOpt{
-		Name:        "device",
-		EntityName:  "device",
-		Description: "description",
-	}, "batch"))
+	assert.Nil(t, store.CreateFeatureGroup(context.Background(), metadata.CreateFeatureGroupOpt{
+		CreateFeatureGroupOpt: types.CreateFeatureGroupOpt{
+			Name:        "device",
+			EntityName:  "device",
+			Description: "description",
+		},
+		Category: types.BatchFeatureCategory,
+	}))
 
 	phoneOpt := metadata.CreateFeatureOpt{
 		CreateFeatureOpt: types.CreateFeatureOpt{
@@ -272,11 +275,14 @@ func TestRichFeature(t *testing.T) {
 		Length:      32,
 		Description: "description",
 	}))
-	assert.Nil(t, store.CreateFeatureGroup(context.Background(), types.CreateFeatureGroupOpt{
-		Name:        "device",
-		EntityName:  "device",
-		Description: "description",
-	}, "batch"))
+	assert.Nil(t, store.CreateFeatureGroup(context.Background(), metadata.CreateFeatureGroupOpt{
+		CreateFeatureGroupOpt: types.CreateFeatureGroupOpt{
+			Name:        "device",
+			EntityName:  "device",
+			Description: "description",
+		},
+		Category: types.BatchFeatureCategory,
+	}))
 	assert.Nil(t, store.CreateFeature(context.Background(), phoneOpt))
 	assert.Nil(t, store.CreateFeature(context.Background(), priceOpt))
 

--- a/internal/database/metadata/postgres/feature_group.go
+++ b/internal/database/metadata/postgres/feature_group.go
@@ -5,15 +5,16 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/onestore-ai/onestore/internal/database/metadata"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
-func (db *DB) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt, category string) error {
-	if category != types.BatchFeatureCategory && category != types.StreamFeatureCategory {
-		return fmt.Errorf("illegal category %s, should be either 'stream' or 'batch'", category)
+func (db *DB) CreateFeatureGroup(ctx context.Context, opt metadata.CreateFeatureGroupOpt) error {
+	if opt.Category != types.BatchFeatureCategory && opt.Category != types.StreamFeatureCategory {
+		return fmt.Errorf("illegal category %s, should be either 'stream' or 'batch'", opt.Category)
 	}
 	query := "insert into feature_group(name, entity_name, category, description) values($1, $2, $3, $4)"
-	_, err := db.ExecContext(ctx, query, opt.Name, opt.EntityName, category, opt.Description)
+	_, err := db.ExecContext(ctx, query, opt.Name, opt.EntityName, opt.Category, opt.Description)
 	return err
 }
 

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -7,6 +7,11 @@ type CreateFeatureOpt struct {
 	ValueType string
 }
 
+type CreateFeatureGroupOpt struct {
+	types.CreateFeatureGroupOpt
+	Category string
+}
+
 type InsertRevisionOpt struct {
 	Revision    int64
 	GroupName   string

--- a/internal/database/offline/postgres/value_type.go
+++ b/internal/database/offline/postgres/value_type.go
@@ -1,8 +1,11 @@
 package postgres
 
-import "github.com/onestore-ai/onestore/pkg/onestore/types"
-import "strings"
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onestore-ai/onestore/pkg/onestore/types"
+)
 
 func (db *DB) ValueTypeTag(dbDataType string) (string, error) {
 	return ValueTypeTag(dbDataType)

--- a/pkg/onestore/feature_group.go
+++ b/pkg/onestore/feature_group.go
@@ -3,11 +3,15 @@ package onestore
 import (
 	"context"
 
+	"github.com/onestore-ai/onestore/internal/database/metadata"
 	"github.com/onestore-ai/onestore/pkg/onestore/types"
 )
 
 func (s *OneStore) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) (*types.FeatureGroup, error) {
-	if err := s.metadata.CreateFeatureGroup(ctx, opt, types.BatchFeatureCategory); err != nil {
+	if err := s.metadata.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
+		CreateFeatureGroupOpt: opt,
+		Category:              types.BatchFeatureCategory,
+	}); err != nil {
 		return nil, err
 	}
 	return s.GetFeatureGroup(ctx, opt.Name)


### PR DESCRIPTION
close #280 

now the method `CreateFeatureGroup` definition is:

```go
CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt, category string) error
```

maybe we should put the parameter `category` in `opt` 