### PR TITLE
refactor(metastore): rename method InsertRevision to CreateRevision

### DIFF
--- a/internal/database/metadata/postgres/database_test.go
+++ b/internal/database/metadata/postgres/database_test.go
@@ -536,24 +536,24 @@ func TestRevision(t *testing.T) {
 		Category: types.BatchFeatureCategory,
 	}))
 
-	opt1 := metadata.InsertRevisionOpt{
+	opt1 := metadata.CreateRevisionOpt{
 		GroupName:   "device_baseinfo",
 		Revision:    20211028,
 		DataTable:   "device_bastinfo_20211028",
 		Description: "description",
 	}
 
-	opt2 := metadata.InsertRevisionOpt{
+	opt2 := metadata.CreateRevisionOpt{
 		GroupName:   "device_baseinfo",
 		Revision:    20211029,
 		DataTable:   "device_bastinfo_20211029",
 		Description: "description",
 	}
 
-	// test InsertRevision
+	// test CreateRevision
 	{
-		assert.Nil(t, store.InsertRevision(context.Background(), opt1))
-		assert.Nil(t, store.InsertRevision(context.Background(), opt2))
+		assert.Nil(t, store.CreateRevision(context.Background(), opt1))
+		assert.Nil(t, store.CreateRevision(context.Background(), opt2))
 	}
 
 	// test GetRevision and GetRevisionsByDataTables

--- a/internal/database/metadata/postgres/revision.go
+++ b/internal/database/metadata/postgres/revision.go
@@ -71,7 +71,7 @@ func (db *DB) GetRevisionsByDataTables(ctx context.Context, dataTables []string)
 	return revisions, nil
 }
 
-func (db *DB) InsertRevision(ctx context.Context, opt metadata.InsertRevisionOpt) error {
+func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) error {
 	query := "INSERT INTO feature_group_revision(group_name, revision, data_table, description) VALUES ($1, $2, $3, $4)"
 	_, err := db.ExecContext(ctx, query, opt.GroupName, opt.Revision, opt.DataTable, opt.Description)
 	if err != nil {

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -36,7 +36,7 @@ type Store interface {
 	GetRevisionsByDataTables(ctx context.Context, dataTables []string) ([]*types.Revision, error)
 	GetLatestRevision(ctx context.Context, groupName string) (*types.Revision, error)
 	BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error)
-	InsertRevision(ctx context.Context, opt InsertRevisionOpt) error
+	CreateRevision(ctx context.Context, opt CreateRevisionOpt) error
 
 	io.Closer
 }

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -12,7 +12,7 @@ type CreateFeatureGroupOpt struct {
 	Category string
 }
 
-type InsertRevisionOpt struct {
+type CreateRevisionOpt struct {
 	Revision    int64
 	GroupName   string
 	DataTable   string

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -96,7 +96,7 @@ func (s *OomStore) ImportBatchFeatures(ctx context.Context, opt types.ImportBatc
 		return err
 	}
 
-	return s.metadata.InsertRevision(ctx, metadata.InsertRevisionOpt{
+	return s.metadata.CreateRevision(ctx, metadata.CreateRevisionOpt{
 		Revision:    revision,
 		GroupName:   opt.GroupName,
 		DataTable:   dataTable,


### PR DESCRIPTION
this PR does:
* rename InsertRevision to CreateRevision
* rename InsertRevisionOpt to CreateRevisionOpt