### PR TITLE
refactor: do not `Get` after `Create`

### DIFF
--- a/featctl/cmd/register_batch_feature.go
+++ b/featctl/cmd/register_batch_feature.go
@@ -23,7 +23,7 @@ var registerBatchFeatureCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		if _, err := oomStore.CreateBatchFeature(ctx, registerBatchFeatureOpt); err != nil {
+		if err := oomStore.CreateBatchFeature(ctx, registerBatchFeatureOpt); err != nil {
 			log.Fatalf("failed registering new feature: %v\n", err)
 		}
 	},

--- a/featctl/cmd/register_entity.go
+++ b/featctl/cmd/register_entity.go
@@ -22,7 +22,7 @@ var registerEntityCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		if _, err := oomStore.CreateEntity(ctx, registerEntityOpt); err != nil {
+		if err := oomStore.CreateEntity(ctx, registerEntityOpt); err != nil {
 			log.Fatalf("failed registering new entity: %v\n", err)
 		}
 	},

--- a/featctl/cmd/register_group.go
+++ b/featctl/cmd/register_group.go
@@ -22,7 +22,7 @@ var registerGroupCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		if _, err := oomStore.CreateFeatureGroup(ctx, registerGroupOpt); err != nil {
+		if err := oomStore.CreateFeatureGroup(ctx, registerGroupOpt); err != nil {
 			log.Fatalf("failed registering new group: %v\n", err)
 		}
 	},

--- a/pkg/oomstore/entity.go
+++ b/pkg/oomstore/entity.go
@@ -6,19 +6,14 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-// CreateEntity create an entity in the store
-func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) (*types.Entity, error) {
-	if err := s.metadata.CreateEntity(ctx, opt); err != nil {
-		return nil, err
-	}
-	return s.GetEntity(ctx, opt.Name)
+func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
+	return s.metadata.CreateEntity(ctx, opt)
 }
 
 func (s *OomStore) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
 	return s.metadata.GetEntity(ctx, name)
 }
 
-// ListEntity: get all entity
 func (s *OomStore) ListEntity(ctx context.Context) ([]*types.Entity, error) {
 	return s.metadata.ListEntity(ctx)
 }

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -20,23 +20,20 @@ func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt
 	return s.metadata.UpdateFeature(ctx, opt)
 }
 
-func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) (*types.Feature, error) {
+func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) error {
 	valueType, err := s.offline.TypeTag(opt.DBValueType)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	group, err := s.metadata.GetFeatureGroup(ctx, opt.GroupName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if group.Category != types.BatchFeatureCategory {
-		return nil, fmt.Errorf("expected batch feature group, got %s feature group", group.Category)
+		return fmt.Errorf("expected batch feature group, got %s feature group", group.Category)
 	}
-	if err := s.metadata.CreateFeature(ctx, metadata.CreateFeatureOpt{
+	return s.metadata.CreateFeature(ctx, metadata.CreateFeatureOpt{
 		CreateFeatureOpt: opt,
 		ValueType:        valueType,
-	}); err != nil {
-		return nil, err
-	}
-	return s.metadata.GetFeature(ctx, opt.FeatureName)
+	})
 }

--- a/pkg/oomstore/feature_group.go
+++ b/pkg/oomstore/feature_group.go
@@ -7,14 +7,11 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func (s *OomStore) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) (*types.FeatureGroup, error) {
-	if err := s.metadata.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
+func (s *OomStore) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) error {
+	return s.metadata.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
 		CreateFeatureGroupOpt: opt,
 		Category:              types.BatchFeatureCategory,
-	}); err != nil {
-		return nil, err
-	}
-	return s.GetFeatureGroup(ctx, opt.Name)
+	})
 }
 
 func (s *OomStore) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
@@ -23,7 +20,6 @@ func (s *OomStore) GetFeatureGroup(ctx context.Context, groupName string) (*type
 
 func (s *OomStore) ListFeatureGroup(ctx context.Context, entityName *string) ([]*types.FeatureGroup, error) {
 	return s.metadata.ListFeatureGroup(ctx, entityName)
-
 }
 
 func (s *OomStore) UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) (int64, error) {


### PR DESCRIPTION
Why:

-  The returned may not be the same as the created because `Create` and `Get` are not in the same transaction.
- One can easily call `Get` when necessary.
- Returning an error is ambiguious for the caller in case `Create` succeeded but `Get` failed