### PR TITLE
refactor(metastore): modify UpdateEntity and UpdateFeature definition

### DIFF
--- a/featctl/cmd/update_entity.go
+++ b/featctl/cmd/update_entity.go
@@ -22,7 +22,7 @@ var updateEntityCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		if err := oomStore.UpdateEntity(ctx, updateEntityOpt); err != nil {
+		if _, err := oomStore.UpdateEntity(ctx, updateEntityOpt); err != nil {
 			log.Fatalf("failed updating entity %s, err %v\n", updateEntityOpt.EntityName, err)
 		}
 	},

--- a/featctl/cmd/update_feature.go
+++ b/featctl/cmd/update_feature.go
@@ -22,7 +22,7 @@ var updateFeatureCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		if err := oomStore.UpdateFeature(ctx, updateFeatureOpt); err != nil {
+		if _, err := oomStore.UpdateFeature(ctx, updateFeatureOpt); err != nil {
 			log.Fatalf("failed updating feature %s, err %v\n", updateFeatureOpt.FeatureName, err)
 		}
 	},

--- a/internal/database/metadata/postgres/database_test.go
+++ b/internal/database/metadata/postgres/database_test.go
@@ -133,19 +133,23 @@ func TestUpdateEntity(t *testing.T) {
 		Description: "description",
 	}))
 
-	assert.Nil(t, db.UpdateEntity(context.Background(), types.UpdateEntityOpt{
+	rowsAffected, err := db.UpdateEntity(context.Background(), types.UpdateEntityOpt{
 		EntityName:     "device",
 		NewDescription: "new description",
-	}))
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), rowsAffected)
 
 	entity, err := db.GetEntity(context.Background(), "device")
 	assert.Nil(t, err)
 	assert.Equal(t, entity.Description, "new description")
 
-	assert.Nil(t, db.UpdateEntity(context.Background(), types.UpdateEntityOpt{
+	rowsAffected, err = db.UpdateEntity(context.Background(), types.UpdateEntityOpt{
 		EntityName:     "invalid_entity_name",
 		NewDescription: "new description",
-	}))
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), rowsAffected)
 }
 
 func TestListEntity(t *testing.T) {
@@ -373,9 +377,11 @@ func TestUpdateFeatuer(t *testing.T) {
 	db := initAndOpenDB(t)
 	defer db.Close()
 
-	assert.Nil(t, db.UpdateFeature(context.Background(), types.UpdateFeatureOpt{
+	rowsAffected, err := db.UpdateFeature(context.Background(), types.UpdateFeatureOpt{
 		FeatureName: "invalid_feature_name",
-	}))
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), rowsAffected)
 
 	assert.Nil(t, db.CreateEntity(context.Background(), types.CreateEntityOpt{
 		Name:        "device",
@@ -402,10 +408,12 @@ func TestUpdateFeatuer(t *testing.T) {
 	}
 	assert.Nil(t, db.CreateFeature(context.Background(), phoneOpt))
 
-	assert.Nil(t, db.UpdateFeature(context.Background(), types.UpdateFeatureOpt{
+	rowsAffected, err = db.UpdateFeature(context.Background(), types.UpdateFeatureOpt{
 		FeatureName:    phoneOpt.FeatureName,
 		NewDescription: "new description",
-	}))
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), rowsAffected)
 
 	feature, err := db.GetFeature(context.Background(), "phone")
 	assert.Nil(t, err)

--- a/internal/database/metadata/postgres/entity.go
+++ b/internal/database/metadata/postgres/entity.go
@@ -39,8 +39,11 @@ func (db *DB) ListEntity(ctx context.Context) ([]*types.Entity, error) {
 	return entities, nil
 }
 
-func (db *DB) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error {
+func (db *DB) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) (int64, error) {
 	query := "UPDATE feature_entity SET description = $1 WHERE name = $2"
-	_, err := db.ExecContext(ctx, query, opt.NewDescription, opt.EntityName)
-	return err
+	if result, err := db.ExecContext(ctx, query, opt.NewDescription, opt.EntityName); err != nil {
+		return 0, err
+	} else {
+		return result.RowsAffected()
+	}
 }

--- a/internal/database/metadata/postgres/feature.go
+++ b/internal/database/metadata/postgres/feature.go
@@ -55,10 +55,13 @@ func (db *DB) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.
 	return features, nil
 }
 
-func (db *DB) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error {
+func (db *DB) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error) {
 	query := "UPDATE feature SET description = $1 WHERE name = $2"
-	_, err := db.ExecContext(ctx, query, opt.NewDescription, opt.FeatureName)
-	return err
+	if result, err := db.ExecContext(ctx, query, opt.NewDescription, opt.FeatureName); err != nil {
+		return 0, err
+	} else {
+		return result.RowsAffected()
+	}
 }
 
 func buildListFeatureCond(opt types.ListFeatureOpt) (string, []interface{}, error) {

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -12,13 +12,13 @@ type Store interface {
 	CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error
 	GetEntity(ctx context.Context, name string) (*types.Entity, error)
 	ListEntity(ctx context.Context) ([]*types.Entity, error)
-	UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error
+	UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) (int64, error)
 
 	// feature
 	CreateFeature(ctx context.Context, opt CreateFeatureOpt) error
 	GetFeature(ctx context.Context, featureName string) (*types.Feature, error)
 	ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error)
-	UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error
+	UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error)
 
 	// feature group
 	CreateFeatureGroup(ctx context.Context, opt CreateFeatureGroupOpt) error

--- a/pkg/oomstore/entity.go
+++ b/pkg/oomstore/entity.go
@@ -23,6 +23,6 @@ func (s *OomStore) ListEntity(ctx context.Context) ([]*types.Entity, error) {
 	return s.metadata.ListEntity(ctx)
 }
 
-func (s *OomStore) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error {
+func (s *OomStore) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) (int64, error) {
 	return s.metadata.UpdateEntity(ctx, opt)
 }

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -16,7 +16,7 @@ func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (t
 	return s.metadata.ListFeature(ctx, opt)
 }
 
-func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error {
+func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error) {
 	return s.metadata.UpdateFeature(ctx, opt)
 }
 


### PR DESCRIPTION
this PR is does:
* re-definition `UpdateEntity(...) error` to `UpdateEntity(...) (int64,error)` 
* re-definition `UpdateFeature(...) error` to `UpdateFeature(...) (int64,error)`

The update method uniformly returns `(rowsAffected int64, err error)`