### PR TITLE
feat(metastore/postgres): merge GetRevisionsByDatatable in ListRevision

### DIFF
--- a/internal/database/metadata/postgres/database_test.go
+++ b/internal/database/metadata/postgres/database_test.go
@@ -572,20 +572,43 @@ func TestListRevision(t *testing.T) {
 	db := initAndOpenDB(t)
 	defer db.Close()
 
-	rs, err := db.ListRevision(context.Background(), nil)
+	rs, err := db.ListRevision(context.Background(), metadata.ListRevisionOpt{})
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(rs))
 
-	opt := metadata.CreateRevisionOpt{
+	opt1 := metadata.CreateRevisionOpt{
 		GroupName:   "device_baseinfo",
 		Revision:    1,
 		DataTable:   "device_bastinfo_20211028",
 		Description: "description",
 	}
 
-	assert.Nil(t, db.CreateRevision(context.Background(), opt))
+	opt2 := metadata.CreateRevisionOpt{
+		GroupName:   "device_baseinfo",
+		Revision:    2,
+		DataTable:   "device_bastinfo_20211029",
+		Description: "description",
+	}
 
-	rs, err = db.ListRevision(context.Background(), nil)
+	assert.Nil(t, db.CreateRevision(context.Background(), opt1))
+	assert.Nil(t, db.CreateRevision(context.Background(), opt2))
+
+	groupName := "device_baseinfo"
+	rs, err = db.ListRevision(context.Background(), metadata.ListRevisionOpt{
+		GroupName: &groupName,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(rs))
+
+	rs, err = db.ListRevision(context.Background(), metadata.ListRevisionOpt{
+		DataTables: []string{},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(rs))
+
+	rs, err = db.ListRevision(context.Background(), metadata.ListRevisionOpt{
+		DataTables: []string{"device_bastinfo_20211028"},
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(rs))
 }

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -31,9 +31,8 @@ type Store interface {
 	ListRichFeatureGroup(ctx context.Context, entityName *string) ([]*types.RichFeatureGroup, error)
 
 	// revision
-	ListRevision(ctx context.Context, groupName *string) ([]*types.Revision, error)
+	ListRevision(ctx context.Context, opt ListRevisionOpt) ([]*types.Revision, error)
 	GetRevision(ctx context.Context, opt GetRevisionOpt) (*types.Revision, error)
-	GetRevisionsByDataTables(ctx context.Context, dataTables []string) ([]*types.Revision, error)
 	GetLatestRevision(ctx context.Context, groupName string) (*types.Revision, error)
 	BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error)
 	CreateRevision(ctx context.Context, opt CreateRevisionOpt) error

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -24,3 +24,8 @@ type GetRevisionOpt struct {
 	Revision   *int64
 	RevisionId *int32
 }
+
+type ListRevisionOpt struct {
+	GroupName  *string
+	DataTables []string
+}

--- a/pkg/oomstore/revision.go
+++ b/pkg/oomstore/revision.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *OomStore) ListRevision(ctx context.Context, groupName *string) ([]*types.Revision, error) {
-	return s.metadata.ListRevision(ctx, groupName)
+	return s.metadata.ListRevision(ctx, metadata.ListRevisionOpt{GroupName: groupName})
 }
 
 func (s *OomStore) GetRevision(ctx context.Context, groupName string, revision int64) (*types.Revision, error) {


### PR DESCRIPTION
this PR does:
* delete method `GetRevisionsByDatatable`
* add type m`etadata.ListRevisionOpt`
* change `ListRevision(context.Context, groupName *string)` to `ListRevision(context.Context, metadata.ListRevisionOpt)`