### PR TITLE
ci: disable unittest in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
   hooks:
   - id: go-fmt
   - id: go-imports
-  - id: go-unit-tests
   - id: golangci-lint
   # - id: go-cyclo
     # args: [-over=20]


### PR DESCRIPTION
Disable unit test in pre-commit config since we already have dedicated test job.