### PR TITLE
fix(types/feature): method Feature.String() will panic when OfflineDataTable is nil

### DIFF
--- a/pkg/oomstore/types/feature.go
+++ b/pkg/oomstore/types/feature.go
@@ -64,7 +64,7 @@ func (rf *Feature) String() string {
 	if rf.OfflineRevision != nil {
 		offlineRevision = fmt.Sprint(*rf.OfflineRevision)
 	}
-	if rf.OfflineDataTable == nil {
+	if rf.OfflineDataTable != nil {
 		offlineDataTable = *rf.OfflineDataTable
 	}
 


### PR DESCRIPTION
method Feature.String() will panic when OfflineDataTable is nil