### PR TITLE
metastore transaction solution 1

### DIFF
--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -6,9 +6,11 @@ package mock_metadata
 
 import (
 	context "context"
+	sql "database/sql"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	sqlx "github.com/jmoiron/sqlx"
 	metadata "github.com/oom-ai/oomstore/internal/database/metadata"
 	types "github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -315,4 +317,202 @@ func (m *MockStore) UpdateRevision(ctx context.Context, opt metadata.UpdateRevis
 func (mr *MockStoreMockRecorder) UpdateRevision(ctx, opt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRevision", reflect.TypeOf((*MockStore)(nil).UpdateRevision), ctx, opt)
+}
+
+// WithTransaction mocks base method.
+func (m *MockStore) WithTransaction(ctx context.Context, fn metadata.TxFn) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithTransaction", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WithTransaction indicates an expected call of WithTransaction.
+func (mr *MockStoreMockRecorder) WithTransaction(ctx, fn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTransaction", reflect.TypeOf((*MockStore)(nil).WithTransaction), ctx, fn)
+}
+
+// MockExtContext is a mock of ExtContext interface.
+type MockExtContext struct {
+	ctrl     *gomock.Controller
+	recorder *MockExtContextMockRecorder
+}
+
+// MockExtContextMockRecorder is the mock recorder for MockExtContext.
+type MockExtContextMockRecorder struct {
+	mock *MockExtContext
+}
+
+// NewMockExtContext creates a new mock instance.
+func NewMockExtContext(ctrl *gomock.Controller) *MockExtContext {
+	mock := &MockExtContext{ctrl: ctrl}
+	mock.recorder = &MockExtContextMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockExtContext) EXPECT() *MockExtContextMockRecorder {
+	return m.recorder
+}
+
+// BindNamed mocks base method.
+func (m *MockExtContext) BindNamed(arg0 string, arg1 interface{}) (string, []interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BindNamed", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].([]interface{})
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// BindNamed indicates an expected call of BindNamed.
+func (mr *MockExtContextMockRecorder) BindNamed(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindNamed", reflect.TypeOf((*MockExtContext)(nil).BindNamed), arg0, arg1)
+}
+
+// DriverName mocks base method.
+func (m *MockExtContext) DriverName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DriverName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// DriverName indicates an expected call of DriverName.
+func (mr *MockExtContextMockRecorder) DriverName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DriverName", reflect.TypeOf((*MockExtContext)(nil).DriverName))
+}
+
+// ExecContext mocks base method.
+func (m *MockExtContext) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExecContext", varargs...)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecContext indicates an expected call of ExecContext.
+func (mr *MockExtContextMockRecorder) ExecContext(ctx, query interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContext", reflect.TypeOf((*MockExtContext)(nil).ExecContext), varargs...)
+}
+
+// GetContext mocks base method.
+func (m *MockExtContext) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, dest, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetContext indicates an expected call of GetContext.
+func (mr *MockExtContextMockRecorder) GetContext(ctx, dest, query interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, dest, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContext", reflect.TypeOf((*MockExtContext)(nil).GetContext), varargs...)
+}
+
+// QueryContext mocks base method.
+func (m *MockExtContext) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryContext", varargs...)
+	ret0, _ := ret[0].(*sql.Rows)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryContext indicates an expected call of QueryContext.
+func (mr *MockExtContextMockRecorder) QueryContext(ctx, query interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryContext", reflect.TypeOf((*MockExtContext)(nil).QueryContext), varargs...)
+}
+
+// QueryRowxContext mocks base method.
+func (m *MockExtContext) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *sqlx.Row {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryRowxContext", varargs...)
+	ret0, _ := ret[0].(*sqlx.Row)
+	return ret0
+}
+
+// QueryRowxContext indicates an expected call of QueryRowxContext.
+func (mr *MockExtContextMockRecorder) QueryRowxContext(ctx, query interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRowxContext", reflect.TypeOf((*MockExtContext)(nil).QueryRowxContext), varargs...)
+}
+
+// QueryxContext mocks base method.
+func (m *MockExtContext) QueryxContext(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryxContext", varargs...)
+	ret0, _ := ret[0].(*sqlx.Rows)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryxContext indicates an expected call of QueryxContext.
+func (mr *MockExtContextMockRecorder) QueryxContext(ctx, query interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryxContext", reflect.TypeOf((*MockExtContext)(nil).QueryxContext), varargs...)
+}
+
+// Rebind mocks base method.
+func (m *MockExtContext) Rebind(arg0 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rebind", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Rebind indicates an expected call of Rebind.
+func (mr *MockExtContextMockRecorder) Rebind(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebind", reflect.TypeOf((*MockExtContext)(nil).Rebind), arg0)
+}
+
+// SelectContext mocks base method.
+func (m *MockExtContext) SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, dest, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SelectContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SelectContext indicates an expected call of SelectContext.
+func (mr *MockExtContextMockRecorder) SelectContext(ctx, dest, query interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, dest, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectContext", reflect.TypeOf((*MockExtContext)(nil).SelectContext), varargs...)
 }

--- a/internal/database/metadata/postgres/database.go
+++ b/internal/database/metadata/postgres/database.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
@@ -31,4 +32,16 @@ func OpenWith(host, port, user, password, database string) (*DB, error) {
 			database),
 	)
 	return &DB{db}, err
+}
+
+type Tx struct {
+	*sqlx.Tx
+}
+
+func openTx(ctx context.Context, db *sqlx.DB) (*Tx, error) {
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &Tx{Tx: tx}, nil
 }

--- a/internal/database/metadata/postgres/db.go
+++ b/internal/database/metadata/postgres/db.go
@@ -1,0 +1,88 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/oom-ai/oomstore/internal/database/dbutil"
+	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+)
+
+// Entity
+func (db *DB) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
+	return createEntity(ctx, db, opt)
+}
+
+func (db *DB) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
+	return getEntity(ctx, db, name)
+}
+
+func (db *DB) ListEntity(ctx context.Context) ([]*types.Entity, error) {
+	return listEntity(ctx, db)
+}
+
+// Feature Group
+func (db *DB) CreateFeatureGroup(ctx context.Context, opt metadata.CreateFeatureGroupOpt) error {
+	return createFeatureGroup(ctx, db, opt)
+}
+
+func (db *DB) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
+	return getFeatureGroup(ctx, db, groupName)
+}
+
+func (db *DB) ListFeatureGroup(ctx context.Context, entityName *string) ([]*types.FeatureGroup, error) {
+	return listFeatureGroup(ctx, db, entityName)
+}
+
+func (db *DB) UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) (int64, error) {
+	return updateFeatureGroup(ctx, db, opt)
+}
+
+// Revison
+func (db *DB) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) ([]*types.Revision, error) {
+	return listRevision(ctx, db, opt)
+}
+func (db *DB) GetRevision(ctx context.Context, opt metadata.GetRevisionOpt) (*types.Revision, error) {
+	return getRevision(ctx, db, opt)
+}
+func (db *DB) UpdateRevision(ctx context.Context, opt metadata.UpdateRevisionOpt) (int64, error) {
+	return updateRevision(ctx, db, opt)
+}
+func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (*types.Revision, error) {
+	return createRevision(ctx, db, opt)
+}
+func (db *DB) GetLatestRevision(ctx context.Context, groupName string) (*types.Revision, error) {
+	return getLatestRevision(ctx, db, groupName)
+}
+
+func (db *DB) BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error) {
+	return buildRevisionRanges(ctx, db, groupName)
+}
+
+// Feature
+func (db *DB) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) error {
+	if err := db.validateDataType(ctx, opt.DBValueType); err != nil {
+		return fmt.Errorf("err when validating value_type input, details: %s", err.Error())
+	}
+	return createFeature(ctx, db, opt)
+}
+
+func (db *DB) GetFeature(ctx context.Context, featureName string) (*types.Feature, error) {
+	return getFeature(ctx, db, featureName)
+}
+
+func (db *DB) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
+	return listFeature(ctx, db, opt)
+}
+
+func (db *DB) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error) {
+	return updateFeature(ctx, db, opt)
+}
+
+func (db *DB) validateDataType(ctx context.Context, dataType string) error {
+	return dbutil.WithTransaction(db.DB, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		return validateDataType(ctx, tx, dataType)
+	})
+}

--- a/internal/database/metadata/postgres/entity.go
+++ b/internal/database/metadata/postgres/entity.go
@@ -6,12 +6,21 @@ import (
 
 	"github.com/jackc/pgerrcode"
 	"github.com/lib/pq"
+	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
 func (db *DB) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
+	return createEntity(ctx, db, opt)
+}
+
+func (tx *Tx) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
+	return createEntity(ctx, tx, opt)
+}
+
+func createEntity(ctx context.Context, ext metadata.ExtContext, opt types.CreateEntityOpt) error {
 	query := "insert into feature_entity(name, length, description) values($1, $2, $3)"
-	_, err := db.ExecContext(ctx, query, opt.Name, opt.Length, opt.Description)
+	_, err := ext.ExecContext(ctx, query, opt.Name, opt.Length, opt.Description)
 	if er, ok := err.(*pq.Error); ok {
 		if er.Code == pgerrcode.UniqueViolation {
 			return fmt.Errorf("entity %s already exists", opt.Name)
@@ -21,27 +30,52 @@ func (db *DB) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error
 }
 
 func (db *DB) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
+	return getEntity(ctx, db, name)
+}
+
+func (tx *Tx) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
+	return getEntity(ctx, tx, name)
+}
+
+func getEntity(ctx context.Context, ext metadata.ExtContext, name string) (*types.Entity, error) {
 	var entity types.Entity
 	query := "select * from feature_entity where name = $1"
-	if err := db.GetContext(ctx, &entity, query, name); err != nil {
+	if err := ext.GetContext(ctx, &entity, query, name); err != nil {
 		return nil, err
 	}
+
 	return &entity, nil
 }
 
 func (db *DB) ListEntity(ctx context.Context) ([]*types.Entity, error) {
+	return listEntity(ctx, db)
+}
+
+func (tx *Tx) ListEntity(ctx context.Context) ([]*types.Entity, error) {
+	return listEntity(ctx, tx)
+}
+
+func listEntity(ctx context.Context, ext metadata.ExtContext) ([]*types.Entity, error) {
 	query := "select * from feature_entity"
 	entities := make([]*types.Entity, 0)
 
-	if err := db.SelectContext(ctx, &entities, query); err != nil {
+	if err := ext.SelectContext(ctx, &entities, query); err != nil {
 		return nil, err
 	}
 	return entities, nil
 }
 
 func (db *DB) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) (int64, error) {
+	return updateEntity(ctx, db, opt)
+}
+
+func (tx *Tx) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) (int64, error) {
+	return updateEntity(ctx, tx, opt)
+}
+
+func updateEntity(ctx context.Context, ext metadata.ExtContext, opt types.UpdateEntityOpt) (int64, error) {
 	query := "UPDATE feature_entity SET description = $1 WHERE name = $2"
-	if result, err := db.ExecContext(ctx, query, opt.NewDescription, opt.EntityName); err != nil {
+	if result, err := ext.ExecContext(ctx, query, opt.NewDescription, opt.EntityName); err != nil {
 		return 0, err
 	} else {
 		return result.RowsAffected()

--- a/internal/database/metadata/postgres/entity.go
+++ b/internal/database/metadata/postgres/entity.go
@@ -10,14 +10,6 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func (db *DB) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
-	return createEntity(ctx, db, opt)
-}
-
-func (tx *Tx) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
-	return createEntity(ctx, tx, opt)
-}
-
 func createEntity(ctx context.Context, ext metadata.ExtContext, opt types.CreateEntityOpt) error {
 	query := "insert into feature_entity(name, length, description) values($1, $2, $3)"
 	_, err := ext.ExecContext(ctx, query, opt.Name, opt.Length, opt.Description)
@@ -29,14 +21,6 @@ func createEntity(ctx context.Context, ext metadata.ExtContext, opt types.Create
 	return err
 }
 
-func (db *DB) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
-	return getEntity(ctx, db, name)
-}
-
-func (tx *Tx) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
-	return getEntity(ctx, tx, name)
-}
-
 func getEntity(ctx context.Context, ext metadata.ExtContext, name string) (*types.Entity, error) {
 	var entity types.Entity
 	query := "select * from feature_entity where name = $1"
@@ -45,14 +29,6 @@ func getEntity(ctx context.Context, ext metadata.ExtContext, name string) (*type
 	}
 
 	return &entity, nil
-}
-
-func (db *DB) ListEntity(ctx context.Context) ([]*types.Entity, error) {
-	return listEntity(ctx, db)
-}
-
-func (tx *Tx) ListEntity(ctx context.Context) ([]*types.Entity, error) {
-	return listEntity(ctx, tx)
 }
 
 func listEntity(ctx context.Context, ext metadata.ExtContext) ([]*types.Entity, error) {

--- a/internal/database/metadata/postgres/feature.go
+++ b/internal/database/metadata/postgres/feature.go
@@ -14,20 +14,6 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func (db *DB) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) error {
-	if err := db.validateDataType(ctx, opt.DBValueType); err != nil {
-		return fmt.Errorf("err when validating value_type input, details: %s", err.Error())
-	}
-	return createFeature(ctx, db, opt)
-}
-
-func (tx *Tx) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) error {
-	if err := tx.validateDataType(ctx, opt.DBValueType); err != nil {
-		return fmt.Errorf("err when validating value_type input, details: %s", err.Error())
-	}
-	return createFeature(ctx, tx, opt)
-}
-
 func createFeature(ctx context.Context, ext metadata.ExtContext, opt metadata.CreateFeatureOpt) error {
 	query := "INSERT INTO feature(name, group_name, db_value_type, value_type, description) VALUES ($1, $2, $3, $4, $5)"
 	_, err := ext.ExecContext(ctx, query, opt.FeatureName, opt.GroupName, opt.DBValueType, opt.ValueType, opt.Description)
@@ -41,14 +27,6 @@ func createFeature(ctx context.Context, ext metadata.ExtContext, opt metadata.Cr
 	return err
 }
 
-func (db *DB) GetFeature(ctx context.Context, featureName string) (*types.Feature, error) {
-	return getFeature(ctx, db, featureName)
-}
-
-func (tx *Tx) GetFeature(ctx context.Context, featureName string) (*types.Feature, error) {
-	return getFeature(ctx, tx, featureName)
-}
-
 func getFeature(ctx context.Context, ext metadata.ExtContext, featureName string) (*types.Feature, error) {
 	var feature types.Feature
 	query := `SELECT * FROM "rich_feature" WHERE name = $1`
@@ -56,14 +34,6 @@ func getFeature(ctx context.Context, ext metadata.ExtContext, featureName string
 		return nil, err
 	}
 	return &feature, nil
-}
-
-func (db *DB) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
-	return listFeature(ctx, db, opt)
-}
-
-func (tx *Tx) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
-	return listFeature(ctx, tx, opt)
 }
 
 func listFeature(ctx context.Context, ext metadata.ExtContext, opt types.ListFeatureOpt) (types.FeatureList, error) {
@@ -80,14 +50,6 @@ func listFeature(ctx context.Context, ext metadata.ExtContext, opt types.ListFea
 		return nil, err
 	}
 	return features, nil
-}
-
-func (db *DB) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error) {
-	return updateFeature(ctx, db, opt)
-}
-
-func (tx *Tx) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error) {
-	return updateFeature(ctx, tx, opt)
 }
 
 func updateFeature(ctx context.Context, ext metadata.ExtContext, opt types.UpdateFeatureOpt) (int64, error) {
@@ -115,15 +77,6 @@ func buildListFeatureCond(opt types.ListFeatureOpt) ([]string, []interface{}, er
 		in["name"] = opt.FeatureNames
 	}
 	return dbutil.BuildConditions(and, in)
-}
-
-func (db *DB) validateDataType(ctx context.Context, dataType string) error {
-	return dbutil.WithTransaction(db.DB, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		return validateDataType(ctx, tx, dataType)
-	})
-}
-func (tx *Tx) validateDataType(ctx context.Context, dataType string) error {
-	return validateDataType(ctx, tx.Tx, dataType)
 }
 
 func validateDataType(ctx context.Context, tx *sqlx.Tx, dataType string) error {

--- a/internal/database/metadata/postgres/feature_group.go
+++ b/internal/database/metadata/postgres/feature_group.go
@@ -13,14 +13,6 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func (db *DB) CreateFeatureGroup(ctx context.Context, opt metadata.CreateFeatureGroupOpt) error {
-	return createFeatureGroup(ctx, db, opt)
-}
-
-func (tx *Tx) CreateFeatureGroup(ctx context.Context, opt metadata.CreateFeatureGroupOpt) error {
-	return createFeatureGroup(ctx, tx, opt)
-}
-
 func createFeatureGroup(ctx context.Context, ext metadata.ExtContext, opt metadata.CreateFeatureGroupOpt) error {
 	if opt.Category != types.BatchFeatureCategory && opt.Category != types.StreamFeatureCategory {
 		return fmt.Errorf("illegal category %s, should be either 'stream' or 'batch'", opt.Category)
@@ -37,14 +29,6 @@ func createFeatureGroup(ctx context.Context, ext metadata.ExtContext, opt metada
 	return err
 }
 
-func (db *DB) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
-	return getFeatureGroup(ctx, db, groupName)
-}
-
-func (tx *Tx) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
-	return getFeatureGroup(ctx, tx, groupName)
-}
-
 func getFeatureGroup(ctx context.Context, ext metadata.ExtContext, groupName string) (*types.FeatureGroup, error) {
 	query := "SELECT * FROM rich_feature_group WHERE name = $1"
 
@@ -56,14 +40,6 @@ func getFeatureGroup(ctx context.Context, ext metadata.ExtContext, groupName str
 		return nil, err
 	}
 	return &group, nil
-}
-
-func (db *DB) ListFeatureGroup(ctx context.Context, entityName *string) ([]*types.FeatureGroup, error) {
-	return listFeatureGroup(ctx, db, entityName)
-}
-
-func (tx *Tx) ListFeatureGroup(ctx context.Context, entityName *string) ([]*types.FeatureGroup, error) {
-	return listFeatureGroup(ctx, tx, entityName)
 }
 
 func listFeatureGroup(ctx context.Context, ext metadata.ExtContext, entityName *string) ([]*types.FeatureGroup, error) {
@@ -82,14 +58,6 @@ func listFeatureGroup(ctx context.Context, ext metadata.ExtContext, entityName *
 		return nil, err
 	}
 	return groups, nil
-}
-
-func (db *DB) UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) (int64, error) {
-	return updateFeatureGroup(ctx, db, opt)
-}
-
-func (tx *Tx) UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) (int64, error) {
-	return updateFeatureGroup(ctx, tx, opt)
 }
 
 func updateFeatureGroup(ctx context.Context, ext metadata.ExtContext, opt types.UpdateFeatureGroupOpt) (int64, error) {

--- a/internal/database/metadata/postgres/revision.go
+++ b/internal/database/metadata/postgres/revision.go
@@ -13,14 +13,6 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func (db *DB) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) ([]*types.Revision, error) {
-	return listRevision(ctx, db, opt)
-}
-
-func (tx *Tx) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) ([]*types.Revision, error) {
-	return listRevision(ctx, tx, opt)
-}
-
 func listRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.ListRevisionOpt) ([]*types.Revision, error) {
 	var revisions []*types.Revision
 	query := "SELECT * FROM feature_group_revision"
@@ -53,14 +45,6 @@ func buildListRevisionCond(opt metadata.ListRevisionOpt) ([]string, []interface{
 	return dbutil.BuildConditions(and, in)
 }
 
-func (db *DB) GetRevision(ctx context.Context, opt metadata.GetRevisionOpt) (*types.Revision, error) {
-	return getRevision(ctx, db, opt)
-}
-
-func (tx *Tx) GetRevision(ctx context.Context, opt metadata.GetRevisionOpt) (*types.Revision, error) {
-	return getRevision(ctx, tx, opt)
-}
-
 func getRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.GetRevisionOpt) (*types.Revision, error) {
 	and := make(map[string]interface{})
 	if opt.GroupName != nil {
@@ -88,14 +72,6 @@ func getRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.GetR
 	return &rs, nil
 }
 
-func (db *DB) UpdateRevision(ctx context.Context, opt metadata.UpdateRevisionOpt) (int64, error) {
-	return updateRevision(ctx, db, opt)
-}
-
-func (tx *Tx) UpdateRevision(ctx context.Context, opt metadata.UpdateRevisionOpt) (int64, error) {
-	return updateRevision(ctx, tx, opt)
-}
-
 func updateRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.UpdateRevisionOpt) (int64, error) {
 	and := make(map[string]interface{})
 	if opt.NewRevision != nil {
@@ -121,14 +97,6 @@ func updateRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.U
 	}
 }
 
-func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (*types.Revision, error) {
-	return createRevision(ctx, db, opt)
-}
-
-func (tx *Tx) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (*types.Revision, error) {
-	return createRevision(ctx, tx, opt)
-}
-
 func createRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.CreateRevisionOpt) (*types.Revision, error) {
 	query := "INSERT INTO feature_group_revision(group_name, revision, data_table, anchored, description) VALUES ($1, $2, $3, $4, $5) RETURNING *"
 	var revision types.Revision
@@ -143,14 +111,6 @@ func createRevision(ctx context.Context, ext metadata.ExtContext, opt metadata.C
 	return &revision, nil
 }
 
-func (db *DB) GetLatestRevision(ctx context.Context, groupName string) (*types.Revision, error) {
-	return getLatestRevision(ctx, db, groupName)
-}
-
-func (tx *Tx) GetLatestRevision(ctx context.Context, groupName string) (*types.Revision, error) {
-	return getLatestRevision(ctx, tx, groupName)
-}
-
 func getLatestRevision(ctx context.Context, ext metadata.ExtContext, groupName string) (*types.Revision, error) {
 	query := "SELECT * FROM feature_group_revision WHERE group_name = $1 ORDER BY create_time DESC LIMIT 1"
 	var revision types.Revision
@@ -158,14 +118,6 @@ func getLatestRevision(ctx context.Context, ext metadata.ExtContext, groupName s
 		return nil, err
 	}
 	return &revision, nil
-}
-
-func (db *DB) BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error) {
-	return buildRevisionRanges(ctx, db, groupName)
-}
-
-func (tx *Tx) BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error) {
-	return buildRevisionRanges(ctx, tx, groupName)
 }
 
 func buildRevisionRanges(ctx context.Context, ext metadata.ExtContext, groupName string) ([]*types.RevisionRange, error) {

--- a/internal/database/metadata/postgres/tx.go
+++ b/internal/database/metadata/postgres/tx.go
@@ -1,0 +1,86 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+)
+
+// Entity
+func (tx *Tx) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) error {
+	return createEntity(ctx, tx, opt)
+}
+
+func (tx *Tx) GetEntity(ctx context.Context, name string) (*types.Entity, error) {
+	return getEntity(ctx, tx, name)
+}
+
+func (tx *Tx) ListEntity(ctx context.Context) ([]*types.Entity, error) {
+	return listEntity(ctx, tx)
+}
+
+// Feature Group
+func (tx *Tx) CreateFeatureGroup(ctx context.Context, opt metadata.CreateFeatureGroupOpt) error {
+	return createFeatureGroup(ctx, tx, opt)
+}
+
+func (tx *Tx) GetFeatureGroup(ctx context.Context, groupName string) (*types.FeatureGroup, error) {
+	return getFeatureGroup(ctx, tx, groupName)
+}
+
+func (tx *Tx) ListFeatureGroup(ctx context.Context, entityName *string) ([]*types.FeatureGroup, error) {
+	return listFeatureGroup(ctx, tx, entityName)
+}
+
+func (tx *Tx) UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) (int64, error) {
+	return updateFeatureGroup(ctx, tx, opt)
+}
+
+// Revison
+func (tx *Tx) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) ([]*types.Revision, error) {
+	return listRevision(ctx, tx, opt)
+}
+
+func (tx *Tx) GetRevision(ctx context.Context, opt metadata.GetRevisionOpt) (*types.Revision, error) {
+	return getRevision(ctx, tx, opt)
+}
+
+func (tx *Tx) UpdateRevision(ctx context.Context, opt metadata.UpdateRevisionOpt) (int64, error) {
+	return updateRevision(ctx, tx, opt)
+}
+
+func (tx *Tx) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (*types.Revision, error) {
+	return createRevision(ctx, tx, opt)
+}
+func (tx *Tx) GetLatestRevision(ctx context.Context, groupName string) (*types.Revision, error) {
+	return getLatestRevision(ctx, tx, groupName)
+}
+
+func (tx *Tx) BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error) {
+	return buildRevisionRanges(ctx, tx, groupName)
+}
+
+// Feature
+func (tx *Tx) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) error {
+	if err := tx.validateDataType(ctx, opt.DBValueType); err != nil {
+		return fmt.Errorf("err when validating value_type input, details: %s", err.Error())
+	}
+	return createFeature(ctx, tx, opt)
+}
+
+func (tx *Tx) GetFeature(ctx context.Context, featureName string) (*types.Feature, error) {
+	return getFeature(ctx, tx, featureName)
+}
+
+func (tx *Tx) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
+	return listFeature(ctx, tx, opt)
+}
+
+func (tx *Tx) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) (int64, error) {
+	return updateFeature(ctx, tx, opt)
+}
+func (tx *Tx) validateDataType(ctx context.Context, dataType string) error {
+	return validateDataType(ctx, tx.Tx, dataType)
+}

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -35,4 +36,11 @@ type Store interface {
 	BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error)
 
 	io.Closer
+}
+
+type ExtContext interface {
+	GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+	SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
+
+	sqlx.ExtContext
 }

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -35,6 +35,9 @@ type Store interface {
 	UpdateRevision(ctx context.Context, opt UpdateRevisionOpt) (int64, error)
 	BuildRevisionRanges(ctx context.Context, groupName string) ([]*types.RevisionRange, error)
 
+	// transaction
+	WithTransaction(ctx context.Context, fn TxFn) error
+
 	io.Closer
 }
 
@@ -44,3 +47,5 @@ type ExtContext interface {
 
 	sqlx.ExtContext
 }
+
+type TxFn func(ctx context.Context, txStore Store) error


### PR DESCRIPTION
- [x] metastore: add tranction sturct 
- [x] metastore/postgres: wrap entity methods with transaction
- [x] metastore/postgres: wrap feature methods with transaction
- [x] metastore/postgres: wrap feature group methods with transaction
- [x] metastore/postgres: wrap revision methods with transaction
- [x]  add a method to use transaction simply

already done! Here is an example of using transaction to create entities and groups in oomstrore:

```go
func applyEntity(ctx context.Context, entity apply.Entity) error {
        ...
	err := s.metadata.WithTransaction(ctx, func(ctx context.Context, txStore metadata.Store) error {
		newEntity, err := txStore.CreateEntity(ctx, entityOpt)
		if err != nil {
			return errr
		}
		group, err := txStore.CreateFeatureGroup(ctx, groupOpt)
		if err != nil {
			return err
		}
		return nil
	})
       ...
}
```