### PR TITLE
cleanup: remove dead code

### DIFF
--- a/internal/database/dbutil/util.go
+++ b/internal/database/dbutil/util.go
@@ -13,10 +13,6 @@ import (
 )
 
 type RowMap = map[string]interface{}
-type RowMapRecord struct {
-	RowMap RowMap
-	Error  error
-}
 
 const (
 	PostgresBatchSize = 10


### PR DESCRIPTION
Is there an automatic way of finding dead code in Go?