### PR TITLE
Jinghan/rename database test package

### DIFF
--- a/internal/database/metadata/postgres/entity_test.go
+++ b/internal/database/metadata/postgres/entity_test.go
@@ -3,21 +3,21 @@ package postgres_test
 import (
 	"testing"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata/test"
+	"github.com/oom-ai/oomstore/internal/database/metadata/test_impl"
 )
 
 func TestCreateEntity(t *testing.T) {
-	test.TestCreateEntity(t, prepareStore)
+	test_impl.TestCreateEntity(t, prepareStore)
 }
 
 func TestGetEntity(t *testing.T) {
-	test.TestGetEntity(t, prepareStore)
+	test_impl.TestGetEntity(t, prepareStore)
 }
 
 func TestUpdateEntity(t *testing.T) {
-	test.TestUpdateEntity(t, prepareStore)
+	test_impl.TestUpdateEntity(t, prepareStore)
 }
 
 func TestListEntity(t *testing.T) {
-	test.TestListEntity(t, prepareStore)
+	test_impl.TestListEntity(t, prepareStore)
 }

--- a/internal/database/metadata/postgres/feature_group_test.go
+++ b/internal/database/metadata/postgres/feature_group_test.go
@@ -3,21 +3,21 @@ package postgres_test
 import (
 	"testing"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata/test"
+	"github.com/oom-ai/oomstore/internal/database/metadata/test_impl"
 )
 
 func TestGetFeatureGroup(t *testing.T) {
-	test.TestGetFeatureGroup(t, prepareStore)
+	test_impl.TestGetFeatureGroup(t, prepareStore)
 }
 
 func TestListFeatureGroup(t *testing.T) {
-	test.TestListFeatureGroup(t, prepareStore)
+	test_impl.TestListFeatureGroup(t, prepareStore)
 }
 
 func TestCreateFeatureGroup(t *testing.T) {
-	test.TestCreateFeatureGroup(t, prepareStore)
+	test_impl.TestCreateFeatureGroup(t, prepareStore)
 }
 
 func TestUpdateFeatureGroup(t *testing.T) {
-	test.TestUpdateFeatureGroup(t, prepareStore)
+	test_impl.TestUpdateFeatureGroup(t, prepareStore)
 }

--- a/internal/database/metadata/postgres/feature_test.go
+++ b/internal/database/metadata/postgres/feature_test.go
@@ -3,33 +3,33 @@ package postgres_test
 import (
 	"testing"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata/test"
+	"github.com/oom-ai/oomstore/internal/database/metadata/test_impl"
 )
 
 func TestCreateFeature(t *testing.T) {
-	test.TestCreateFeature(t, prepareStore)
+	test_impl.TestCreateFeature(t, prepareStore)
 }
 
 func TestCreateFeatureWithSameName(t *testing.T) {
-	test.TestCreateFeatureWithSameName(t, prepareStore)
+	test_impl.TestCreateFeatureWithSameName(t, prepareStore)
 }
 
 func TestCreateFeatureWithSQLKeywrod(t *testing.T) {
-	test.TestCreateFeatureWithSQLKeywrod(t, prepareStore)
+	test_impl.TestCreateFeatureWithSQLKeywrod(t, prepareStore)
 }
 
 func TestCreateFeatureWithInvalidDataType(t *testing.T) {
-	test.TestCreateFeatureWithInvalidDataType(t, prepareStore)
+	test_impl.TestCreateFeatureWithInvalidDataType(t, prepareStore)
 }
 
 func TestGetFeature(t *testing.T) {
-	test.TestGetFeature(t, prepareStore)
+	test_impl.TestGetFeature(t, prepareStore)
 }
 
 func TestListFeature(t *testing.T) {
-	test.TestListFeature(t, prepareStore)
+	test_impl.TestListFeature(t, prepareStore)
 }
 
 func TestUpdateFeature(t *testing.T) {
-	test.TestUpdateFeature(t, prepareStore)
+	test_impl.TestUpdateFeature(t, prepareStore)
 }

--- a/internal/database/metadata/postgres/revision_test.go
+++ b/internal/database/metadata/postgres/revision_test.go
@@ -3,25 +3,25 @@ package postgres_test
 import (
 	"testing"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata/test"
+	"github.com/oom-ai/oomstore/internal/database/metadata/test_impl"
 )
 
 func TestCreateRevision(t *testing.T) {
-	test.TestCreateRevision(t, prepareStore)
+	test_impl.TestCreateRevision(t, prepareStore)
 }
 
 func TestUpdateRevision(t *testing.T) {
-	test.TestUpdateRevision(t, prepareStore)
+	test_impl.TestUpdateRevision(t, prepareStore)
 }
 
 func TestGetRevision(t *testing.T) {
-	test.TestGetRevision(t, prepareStore)
+	test_impl.TestGetRevision(t, prepareStore)
 }
 
 func TestGetRevisionBy(t *testing.T) {
-	test.TestGetRevisionBy(t, prepareStore)
+	test_impl.TestGetRevisionBy(t, prepareStore)
 }
 
 func TestListRevision(t *testing.T) {
-	test.TestListRevision(t, prepareStore)
+	test_impl.TestListRevision(t, prepareStore)
 }

--- a/internal/database/metadata/test_impl/entity.go
+++ b/internal/database/metadata/test_impl/entity.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"fmt"

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"context"

--- a/internal/database/metadata/test_impl/feature_group.go
+++ b/internal/database/metadata/test_impl/feature_group.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"context"

--- a/internal/database/metadata/test_impl/helper.go
+++ b/internal/database/metadata/test_impl/helper.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 func boolPtr(i bool) *bool {
 	return &i

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"context"

--- a/internal/database/metadata/test_impl/util.go
+++ b/internal/database/metadata/test_impl/util.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"context"

--- a/internal/database/offline/postgres/type_tag_test.go
+++ b/internal/database/offline/postgres/type_tag_test.go
@@ -1,8 +1,9 @@
-package postgres
+package postgres_test
 
 import (
 	"testing"
 
+	"github.com/oom-ai/oomstore/internal/database/offline/postgres"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -28,7 +29,7 @@ func TestValueTypeTag(t *testing.T) {
 			types.TIME,
 		},
 	} {
-		actual, err := TypeTag(tt.input)
+		actual, err := postgres.TypeTag(tt.input)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/online/postgres/database_test.go
+++ b/internal/database/online/postgres/database_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
-	"github.com/oom-ai/oomstore/internal/database/online/test"
+	"github.com/oom-ai/oomstore/internal/database/online/test_impl"
 	"github.com/oom-ai/oomstore/internal/database/test/runtime_pg"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -19,7 +19,7 @@ func prepareStore() (context.Context, online.Store) {
 		Port:     opt.Port,
 		User:     opt.User,
 		Password: opt.Password,
-		Database: "test",
+		Database: "test_impl",
 	})
 	if err != nil {
 		panic(err)
@@ -43,25 +43,25 @@ func prepareStore() (context.Context, online.Store) {
 }
 
 func TestOpen(t *testing.T) {
-	test.TestOpen(t, prepareStore)
+	test_impl.TestOpen(t, prepareStore)
 }
 
 func TestGetExisted(t *testing.T) {
-	test.TestGetExisted(t, prepareStore)
+	test_impl.TestGetExisted(t, prepareStore)
 }
 
 func TestGetNotExistedEntityKey(t *testing.T) {
-	test.TestGetNotExistedEntityKey(t, prepareStore)
+	test_impl.TestGetNotExistedEntityKey(t, prepareStore)
 }
 
 func TestMultiGet(t *testing.T) {
-	test.TestMultiGet(t, prepareStore)
+	test_impl.TestMultiGet(t, prepareStore)
 }
 
 func TestPurgeRemovesSpecifiedRevision(t *testing.T) {
-	test.TestPurgeRemovesSpecifiedRevision(t, prepareStore)
+	test_impl.TestPurgeRemovesSpecifiedRevision(t, prepareStore)
 }
 
 func TestPurgeNotRemovesOtherRevisions(t *testing.T) {
-	test.TestPurgeNotRemovesOtherRevisions(t, prepareStore)
+	test_impl.TestPurgeNotRemovesOtherRevisions(t, prepareStore)
 }

--- a/internal/database/online/postgres/database_test.go
+++ b/internal/database/online/postgres/database_test.go
@@ -1,4 +1,4 @@
-package postgres
+package postgres_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
+	"github.com/oom-ai/oomstore/internal/database/online/postgres"
 	"github.com/oom-ai/oomstore/internal/database/online/test_impl"
 	"github.com/oom-ai/oomstore/internal/database/test/runtime_pg"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -14,12 +15,12 @@ import (
 func prepareStore() (context.Context, online.Store) {
 	ctx := context.Background()
 	opt := runtime_pg.PostgresDbOpt
-	store, err := Open(&types.PostgresOpt{
+	store, err := postgres.Open(&types.PostgresOpt{
 		Host:     opt.Host,
 		Port:     opt.Port,
 		User:     opt.User,
 		Password: opt.Password,
-		Database: "test_impl",
+		Database: "test",
 	})
 	if err != nil {
 		panic(err)
@@ -35,7 +36,7 @@ func prepareStore() (context.Context, online.Store) {
 		panic(err)
 	}
 
-	store, err = Open(&opt)
+	store, err = postgres.Open(&opt)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/database/online/redis/database_test.go
+++ b/internal/database/online/redis/database_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
-	"github.com/oom-ai/oomstore/internal/database/online/test"
+	"github.com/oom-ai/oomstore/internal/database/online/test_impl"
 	"github.com/oom-ai/oomstore/internal/database/test/runtime_redis"
 )
 
@@ -20,25 +20,25 @@ func prepareStore() (context.Context, online.Store) {
 }
 
 func TestOpen(t *testing.T) {
-	test.TestOpen(t, prepareStore)
+	test_impl.TestOpen(t, prepareStore)
 }
 
 func TestGetExisted(t *testing.T) {
-	test.TestGetExisted(t, prepareStore)
+	test_impl.TestGetExisted(t, prepareStore)
 }
 
 func TestGetNotExistedEntityKey(t *testing.T) {
-	test.TestGetNotExistedEntityKey(t, prepareStore)
+	test_impl.TestGetNotExistedEntityKey(t, prepareStore)
 }
 
 func TestMultiGet(t *testing.T) {
-	test.TestMultiGet(t, prepareStore)
+	test_impl.TestMultiGet(t, prepareStore)
 }
 
 func TestPurgeRemovesSpecifiedRevision(t *testing.T) {
-	test.TestPurgeRemovesSpecifiedRevision(t, prepareStore)
+	test_impl.TestPurgeRemovesSpecifiedRevision(t, prepareStore)
 }
 
 func TestPurgeNotRemovesOtherRevisions(t *testing.T) {
-	test.TestPurgeNotRemovesOtherRevisions(t, prepareStore)
+	test_impl.TestPurgeNotRemovesOtherRevisions(t, prepareStore)
 }

--- a/internal/database/online/redis/database_test.go
+++ b/internal/database/online/redis/database_test.go
@@ -1,17 +1,18 @@
-package redis
+package redis_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
+	"github.com/oom-ai/oomstore/internal/database/online/redis"
 	"github.com/oom-ai/oomstore/internal/database/online/test_impl"
 	"github.com/oom-ai/oomstore/internal/database/test/runtime_redis"
 )
 
 func prepareStore() (context.Context, online.Store) {
 	ctx := context.Background()
-	store := Open(&runtime_redis.RedisDbOpt)
+	store := redis.Open(&runtime_redis.RedisDbOpt)
 	if _, err := store.FlushDB(ctx).Result(); err != nil {
 		panic(err)
 	}

--- a/internal/database/online/test_impl/get.go
+++ b/internal/database/online/test_impl/get.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"testing"

--- a/internal/database/online/test_impl/open.go
+++ b/internal/database/online/test_impl/open.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"testing"

--- a/internal/database/online/test_impl/purge.go
+++ b/internal/database/online/test_impl/purge.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"testing"

--- a/internal/database/online/test_impl/util.go
+++ b/internal/database/online/test_impl/util.go
@@ -1,4 +1,4 @@
-package test
+package test_impl
 
 import (
 	"context"


### PR DESCRIPTION
This PR does:
- renames online and metadata `test` package to `test_impl`
- add `_test` suffix for test files