### PR TITLE
Jinghan/remove GroupName from ImportOpt

### DIFF
--- a/internal/database/offline/test_impl/import.go
+++ b/internal/database/offline/test_impl/import.go
@@ -23,7 +23,6 @@ func TestImport(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	dataTable := "data_1_1"
 
 	opt := offline.ImportOpt{
-		GroupName:     "device",
 		Entity:        &entity,
 		DataTableName: dataTable,
 		Features: []*types.Feature{

--- a/internal/database/offline/test_impl/util.go
+++ b/internal/database/offline/test_impl/util.go
@@ -22,7 +22,6 @@ func buildTestDataTable(ctx context.Context, t *testing.T, store offline.Store, 
 		header = append(header, f.Name)
 	}
 	opt := offline.ImportOpt{
-		GroupName:     "device_info",
 		Entity:        entity,
 		DataTableName: dataTable,
 		Features:      features,

--- a/internal/database/offline/types.go
+++ b/internal/database/offline/types.go
@@ -30,7 +30,6 @@ type JoinOneFeatureGroupOpt struct {
 }
 
 type ImportOpt struct {
-	GroupName     string
 	Entity        *types.Entity
 	Features      types.FeatureList
 	Header        []string

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -92,7 +92,6 @@ func (s *OomStore) ImportBatchFeatures(ctx context.Context, opt types.ImportBatc
 	}
 
 	revision, err = s.offline.Import(ctx, offline.ImportOpt{
-		GroupName:     group.Name,
 		Entity:        entity,
 		Features:      features,
 		Header:        header,


### PR DESCRIPTION
This PR does:
- remove `GroupName` from `ImportOpt` because data_table is now named as `data_<group_id>_<revision_id>`
- avoid rename in `Import` because `DataTableName` is already generated before import
- update callers of offline method `Import`