### PR TITLE
Jinghan/embed types.CreateFeatureOpt to metadata.CreateFeatureOpt

### DIFF
--- a/featctl/cmd/register_batch_feature.go
+++ b/featctl/cmd/register_batch_feature.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"log"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
 )
 
 type registerBatchFeatureOption struct {
-	metadata.CreateFeatureOpt
+	types.CreateFeatureOpt
 	groupName string
 }
 
@@ -21,7 +21,7 @@ var registerBatchFeatureCmd = &cobra.Command{
 	Example: `featctl register feature model --group device --value-type "varchar(30)" --description 'phone model'`,
 	Args:    cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
-		registerBatchFeatureOpt.Name = args[0]
+		registerBatchFeatureOpt.FeatureName = args[0]
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()

--- a/internal/database/metadata/postgres/feature.go
+++ b/internal/database/metadata/postgres/feature.go
@@ -16,11 +16,11 @@ func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metada
 	}
 	var featureId int
 	query := "INSERT INTO feature(name, group_id, db_value_type, value_type, description) VALUES ($1, $2, $3, $4, $5) RETURNING id"
-	err := sqlxCtx.GetContext(ctx, &featureId, query, opt.Name, opt.GroupID, opt.DBValueType, opt.ValueType, opt.Description)
+	err := sqlxCtx.GetContext(ctx, &featureId, query, opt.FeatureName, opt.GroupID, opt.DBValueType, opt.ValueType, opt.Description)
 	if err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
-				return 0, fmt.Errorf("feature %s already exists", opt.Name)
+				return 0, fmt.Errorf("feature %s already exists", opt.FeatureName)
 			}
 		}
 	}

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -36,11 +36,13 @@ func TestCreateFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		Name:        "phone",
-		GroupID:     groupID,
-		DBValueType: "varchar(16)",
-		Description: "description",
-		ValueType:   "string",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "phone",
+			GroupID:     groupID,
+			DBValueType: "varchar(16)",
+			Description: "description",
+		},
+		ValueType: "string",
 	}
 
 	_, err := store.CreateFeature(ctx, opt)
@@ -53,9 +55,11 @@ func TestCreateFeatureWithSameName(t *testing.T, prepareStore PrepareStoreRuntim
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		Name:        "phone",
-		GroupID:     groupID,
-		DBValueType: "varchar(16)",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "phone",
+			GroupID:     groupID,
+			DBValueType: "varchar(16)",
+		},
 	}
 
 	_, err := store.CreateFeature(ctx, opt)
@@ -71,10 +75,12 @@ func TestCreateFeatureWithSQLKeywrod(t *testing.T, prepareStore PrepareStoreRunt
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		Name:        "user",
-		GroupID:     groupID,
-		DBValueType: "int",
-		Description: "order",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "user",
+			GroupID:     groupID,
+			DBValueType: "int",
+			Description: "order",
+		},
 	}
 
 	_, err := store.CreateFeature(ctx, opt)
@@ -87,9 +93,11 @@ func TestCreateFeatureWithInvalidDataType(t *testing.T, prepareStore PrepareStor
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	_, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		Name:        "model",
-		GroupID:     groupID,
-		DBValueType: "invalid_type",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "model",
+			GroupID:     groupID,
+			DBValueType: "invalid_type",
+		},
 	})
 	require.Error(t, err)
 }
@@ -100,11 +108,13 @@ func TestGetFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	id, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		Name:        "phone",
-		GroupID:     groupID,
-		DBValueType: "varchar(16)",
-		Description: "description",
-		ValueType:   "string",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "phone",
+			GroupID:     groupID,
+			DBValueType: "varchar(16)",
+			Description: "description",
+		},
+		ValueType: "string",
 	})
 	require.NoError(t, err)
 
@@ -130,11 +140,13 @@ func TestListFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.Equal(t, 0, features.Len())
 
 	featureID, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		Name:        "phone",
-		GroupID:     groupID,
-		DBValueType: "varchar(16)",
-		Description: "description",
-		ValueType:   "string",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "phone",
+			GroupID:     groupID,
+			DBValueType: "varchar(16)",
+			Description: "description",
+		},
+		ValueType: "string",
 	})
 	require.NoError(t, err)
 
@@ -172,11 +184,13 @@ func TestUpdateFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		Name:        "phone",
-		GroupID:     groupID,
-		DBValueType: "varchar(16)",
-		Description: "description",
-		ValueType:   "string",
+		CreateFeatureOpt: types.CreateFeatureOpt{
+			FeatureName: "phone",
+			GroupID:     groupID,
+			DBValueType: "varchar(16)",
+			Description: "description",
+		},
+		ValueType: "string",
 	}
 	id, err := store.CreateFeature(ctx, opt)
 	require.NoError(t, err)

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -1,5 +1,7 @@
 package metadata
 
+import "github.com/oom-ai/oomstore/pkg/oomstore/types"
+
 type RevisionRange struct {
 	MinRevision int64  `db:"min_revision"`
 	MaxRevision int64  `db:"max_revision"`
@@ -14,11 +16,8 @@ type CreateEntityOpt struct {
 }
 
 type CreateFeatureOpt struct {
-	Name        string
-	GroupID     int
-	DBValueType string
-	Description string
-	ValueType   string
+	types.CreateFeatureOpt
+	ValueType string
 }
 
 type CreateFeatureGroupOpt struct {

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -24,7 +24,7 @@ func (s *OomStore) UpdateFeature(ctx context.Context, opt metadata.UpdateFeature
 	return s.metadata.UpdateFeature(ctx, opt)
 }
 
-func (s *OomStore) CreateBatchFeature(ctx context.Context, opt metadata.CreateFeatureOpt) (int, error) {
+func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) (int, error) {
 	group, err := s.metadata.GetFeatureGroup(ctx, opt.GroupID)
 	if err != nil {
 		return 0, err
@@ -33,8 +33,12 @@ func (s *OomStore) CreateBatchFeature(ctx context.Context, opt metadata.CreateFe
 		return 0, fmt.Errorf("expected batch feature group, got %s feature group", group.Category)
 	}
 
-	if opt.ValueType, err = s.offline.TypeTag(opt.DBValueType); err != nil {
+	valueType, err := s.offline.TypeTag(opt.DBValueType)
+	if err != nil {
 		return 0, err
 	}
-	return s.metadata.CreateFeature(ctx, opt)
+	return s.metadata.CreateFeature(ctx, metadata.CreateFeatureOpt{
+		CreateFeatureOpt: opt,
+		ValueType:        valueType,
+	})
 }

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -6,7 +6,7 @@ import (
 
 type CreateFeatureOpt struct {
 	FeatureName string
-	GroupID     string
+	GroupID     int
 	DBValueType string
 	Description string
 }


### PR DESCRIPTION
Currently, `types.CreateFeatureOpt` is not used in codebase, while `metadata.CreateFeatureOpt` is used in `database`, `oomstore` and `featctl`.

This PR embeds `types.CreateFeatureOpt` to `metadata.CreateFeatureOpt`, so that `metadata.CreateFeatureOpt` is only used in `database`, while `types.CreateFeatureOpt` used in `oomstore` and `featctl`.


related to #490 