### PR TITLE
Jinghan/separate types.UpdateFeatureOpt and metadata.UpdateFeatureOpt

### DIFF
--- a/featctl/cmd/update_feature.go
+++ b/featctl/cmd/update_feature.go
@@ -4,30 +4,26 @@ import (
 	"context"
 	"log"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
 )
 
-var updateFeatureOpt metadata.UpdateFeatureOpt
+var updateFeatureOpt types.UpdateFeatureOpt
 
 var updateFeatureCmd = &cobra.Command{
 	Use:   "feature",
 	Short: "update a specified feature",
 	Args:  cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		updateFeatureOpt.FeatureName = args[0]
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		featureName := args[0]
-		feature, err := oomStore.GetFeatureByName(ctx, featureName)
-		if err != nil {
-			log.Fatalf("failed to get feature name=%s: %v", featureName, err)
-		}
-		updateFeatureOpt.FeatureID = feature.ID
-
 		if err := oomStore.UpdateFeature(ctx, updateFeatureOpt); err != nil {
-			log.Fatalf("failed to update feature %d, err %v\n", feature.ID, err)
+			log.Fatalf("failed to update feature %s, err %v\n", updateFeatureOpt.FeatureName, err)
 		}
 	},
 }

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -20,8 +20,15 @@ func (s *OomStore) ListFeature(ctx context.Context, opt metadata.ListFeatureOpt)
 	return s.metadata.ListFeature(ctx, opt)
 }
 
-func (s *OomStore) UpdateFeature(ctx context.Context, opt metadata.UpdateFeatureOpt) error {
-	return s.metadata.UpdateFeature(ctx, opt)
+func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error {
+	feature, err := s.metadata.GetFeatureByName(ctx, opt.FeatureName)
+	if err != nil {
+		return err
+	}
+	return s.metadata.UpdateFeature(ctx, metadata.UpdateFeatureOpt{
+		FeatureID:      feature.ID,
+		NewDescription: opt.NewDescription,
+	})
 }
 
 func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) (int, error) {


### PR DESCRIPTION
This PR separates the usages of `types.UpdateFeatureOpt` and `metadata.UpdateFeatureOpt`:
- `metadata.UpdateFeatureOpt`: used in `internal/database`
- `types.UpdateFeatureOpt`: used in `pkg/oomstore` and `featctl`

related to #490 