### PR TITLE
Jinghan/separate types.ListFeatureOpt and metadata.ListFeatureOpt

### DIFF
--- a/featctl/cmd/join_historical_feature_helper.go
+++ b/featctl/cmd/join_historical_feature_helper.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cast"
@@ -26,7 +25,7 @@ func joinHistoricalFeatures(ctx context.Context, store *oomstore.OomStore, opt J
 		return err
 	}
 
-	features := store.ListFeature(ctx, metadata.ListFeatureOpt{
+	features, err := store.ListFeature(ctx, types.ListFeatureOpt{
 		FeatureNames: &opt.FeatureNames,
 	})
 	if err != nil {

--- a/pkg/oomstore/export.go
+++ b/pkg/oomstore/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/internal/database/offline"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -16,7 +15,12 @@ func (s *OomStore) ExportFeatureValues(ctx context.Context, opt types.ExportFeat
 	}
 
 	featureNames := opt.FeatureNames
-	allFeatures := s.ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.GroupID})
+	allFeatures, err := s.ListFeature(ctx, types.ListFeatureOpt{
+		GroupName: &revision.Group.Name,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
 
 	allFeatureNames := allFeatures.Names()
 	if len(featureNames) == 0 {

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -16,8 +16,25 @@ func (s *OomStore) GetFeatureByName(ctx context.Context, name string) (*types.Fe
 	return s.metadata.GetFeatureByName(ctx, name)
 }
 
-func (s *OomStore) ListFeature(ctx context.Context, opt metadata.ListFeatureOpt) types.FeatureList {
-	return s.metadata.ListFeature(ctx, opt)
+func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
+	metadataOpt := metadata.ListFeatureOpt{
+		FeatureNames: opt.FeatureNames,
+	}
+	if opt.EntityName != nil {
+		entity, err := s.metadata.GetEntityByName(ctx, *opt.EntityName)
+		if err != nil {
+			return nil, err
+		}
+		metadataOpt.EntityID = &entity.ID
+	}
+	if opt.GroupName != nil {
+		group, err := s.metadata.GetFeatureGroupByName(ctx, *opt.GroupName)
+		if err != nil {
+			return nil, err
+		}
+		metadataOpt.GroupID = &group.ID
+	}
+	return s.metadata.ListFeature(ctx, metadataOpt), nil
 }
 
 func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error {

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -24,7 +24,9 @@ func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
 		return fmt.Errorf("the specific revision was synced to the online store, won't do it again this time")
 	}
 
-	features := s.ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &group.ID})
+	features, err := s.ListFeature(ctx, types.ListFeatureOpt{
+		GroupName: &group.Name,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -14,7 +14,7 @@ type CreateFeatureOpt struct {
 type ListFeatureOpt struct {
 	EntityName   *string
 	GroupName    *string
-	FeatureNames []string
+	FeatureNames *[]string
 }
 
 type UpdateFeatureOpt struct {


### PR DESCRIPTION
This PR does:
- `types.ListFeatureOpt`: used in `pkg/oomstore` and `featctl`
- `metadata.ListFeatureOpt`: used in `internal/database`.

related to #490 