### PR TITLE
Jinghan/use types.CreateEntityOpt and types.UpdateEntityOpt in oomstore

### DIFF
--- a/featctl/cmd/register_entity.go
+++ b/featctl/cmd/register_entity.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"log"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
 )
 
-var registerEntityOpt metadata.CreateEntityOpt
+var registerEntityOpt types.CreateEntityOpt
 
 var registerEntityCmd = &cobra.Command{
 	Use:   "entity",
 	Short: "register a new entity",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
-		registerEntityOpt.Name = args[0]
+		registerEntityOpt.EntityName = args[0]
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()

--- a/featctl/cmd/update_entity.go
+++ b/featctl/cmd/update_entity.go
@@ -4,29 +4,26 @@ import (
 	"context"
 	"log"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
 )
 
-var updateEntityOpt metadata.UpdateEntityOpt
+var updateEntityOpt types.UpdateEntityOpt
 
 var updateEntityCmd = &cobra.Command{
 	Use:   "entity",
 	Short: "update a specified entity",
 	Args:  cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		updateEntityOpt.EntityName = args[0]
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		entityName := args[0]
-		entity, err := oomStore.GetEntityByName(ctx, entityName)
-		if err != nil {
-			log.Fatalf("failed to get entity by name=%s: %v", entityName, err)
-		}
-		updateEntityOpt.EntityID = entity.ID
 		if err := oomStore.UpdateEntity(ctx, updateEntityOpt); err != nil {
-			log.Fatalf("failed to update entity id=%d, err %v\n", updateEntityOpt.EntityID, err)
+			log.Fatalf("failed to update entity id=%s, err %v\n", updateEntityOpt.EntityName, err)
 		}
 	},
 }

--- a/internal/database/metadata/postgres/entity.go
+++ b/internal/database/metadata/postgres/entity.go
@@ -12,10 +12,10 @@ import (
 func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateEntityOpt) (int, error) {
 	var entityId int
 	query := "insert into feature_entity(name, length, description) values($1, $2, $3) returning id"
-	err := sqlxCtx.GetContext(ctx, &entityId, query, opt.Name, opt.Length, opt.Description)
+	err := sqlxCtx.GetContext(ctx, &entityId, query, opt.EntityName, opt.Length, opt.Description)
 	if er, ok := err.(*pq.Error); ok {
 		if er.Code == pgerrcode.UniqueViolation {
-			return 0, fmt.Errorf("entity %s already exists", opt.Name)
+			return 0, fmt.Errorf("entity %s already exists", opt.EntityName)
 		}
 	}
 	return entityId, err

--- a/internal/database/metadata/test_impl/entity.go
+++ b/internal/database/metadata/test_impl/entity.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
@@ -14,17 +15,21 @@ func TestCreateEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	defer store.Close()
 
 	opt := metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	}
 	_, err := store.CreateEntity(ctx, opt)
 	require.NoError(t, err)
 
 	_, err = store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	})
 	require.Equal(t, err, fmt.Errorf("entity device already exists"))
 }
@@ -34,9 +39,11 @@ func TestGetEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	defer store.Close()
 
 	opt := metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	}
 
 	id, err := store.CreateEntity(ctx, opt)
@@ -46,7 +53,7 @@ func TestGetEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 
 	entity, err := store.GetEntity(ctx, id)
 	require.NoError(t, err)
-	require.Equal(t, opt.Name, entity.Name)
+	require.Equal(t, opt.EntityName, entity.Name)
 	require.Equal(t, opt.Length, entity.Length)
 	require.Equal(t, opt.Description, entity.Description)
 
@@ -59,9 +66,11 @@ func TestUpdateEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	defer store.Close()
 
 	id, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	})
 	require.NoError(t, err)
 
@@ -92,9 +101,11 @@ func TestListEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.Equal(t, 0, len(entitys))
 
 	_, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	})
 	require.NoError(t, err)
 
@@ -103,9 +114,11 @@ func TestListEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	entitys = store.ListEntity(ctx)
 	require.Equal(t, 1, len(entitys))
 	_, err = store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        "user",
-		Length:      16,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "user",
+			Length:      16,
+			Description: "description",
+		},
 	})
 	require.NoError(t, err)
 

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -13,9 +13,11 @@ import (
 
 func prepareEntityAndGroup(t *testing.T, ctx context.Context, store metadata.Store) (int, int) {
 	entityID, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	})
 	require.NoError(t, err)
 

--- a/internal/database/metadata/test_impl/feature_group.go
+++ b/internal/database/metadata/test_impl/feature_group.go
@@ -12,9 +12,11 @@ import (
 
 func prepareEntity(t *testing.T, ctx context.Context, store metadata.Store, name string) int {
 	entityId, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        name,
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  name,
+			Length:      32,
+			Description: "description",
+		},
 	})
 	require.NoError(t, err)
 	return entityId

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -343,9 +343,11 @@ func ignoreCreateAndModifyTime(revision *types.Revision) {
 
 func prepareRevisions(t *testing.T, ctx context.Context, store metadata.Store) (int, int, []int, types.RevisionList) {
 	entityID, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		Name:        "device",
-		Length:      32,
-		Description: "description",
+		CreateEntityOpt: types.CreateEntityOpt{
+			EntityName:  "device",
+			Length:      32,
+			Description: "description",
+		},
 	})
 	require.NoError(t, err)
 

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -10,9 +10,7 @@ type RevisionRange struct {
 
 // Create
 type CreateEntityOpt struct {
-	Name        string
-	Length      int
-	Description string
+	types.CreateEntityOpt
 }
 
 type CreateFeatureOpt struct {

--- a/pkg/oomstore/entity.go
+++ b/pkg/oomstore/entity.go
@@ -19,8 +19,10 @@ func (s *OomStore) ListEntity(ctx context.Context) types.EntityList {
 	return s.metadata.ListEntity(ctx)
 }
 
-func (s *OomStore) CreateEntity(ctx context.Context, opt metadata.CreateEntityOpt) (int, error) {
-	return s.metadata.CreateEntity(ctx, opt)
+func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) (int, error) {
+	return s.metadata.CreateEntity(ctx, metadata.CreateEntityOpt{
+		CreateEntityOpt: opt,
+	})
 }
 
 func (s *OomStore) UpdateEntity(ctx context.Context, opt metadata.UpdateEntityOpt) error {

--- a/pkg/oomstore/entity.go
+++ b/pkg/oomstore/entity.go
@@ -25,6 +25,13 @@ func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) 
 	})
 }
 
-func (s *OomStore) UpdateEntity(ctx context.Context, opt metadata.UpdateEntityOpt) error {
-	return s.metadata.UpdateEntity(ctx, opt)
+func (s *OomStore) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error {
+	entity, err := s.metadata.GetEntityByName(ctx, opt.EntityName)
+	if err != nil {
+		return err
+	}
+	return s.metadata.UpdateEntity(ctx, metadata.UpdateEntityOpt{
+		EntityID:       entity.ID,
+		NewDescription: opt.NewDescription,
+	})
 }

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -23,7 +23,7 @@ type UpdateFeatureOpt struct {
 }
 
 type CreateEntityOpt struct {
-	Name        string
+	EntityName  string
 	Length      int
 	Description string
 }


### PR DESCRIPTION
This PR does:
- separate `types.CreateEntityOpt` and `metadata.CreateEntityOpt`
- separate `types.UpdateEntityOpt` and `metadata.UpdateEntityOpt`

related to #490 