### PR TITLE
refactor: unify id spelling

### DIFF
--- a/featctl/cmd/join_historical_feature_helper.go
+++ b/featctl/cmd/join_historical_feature_helper.go
@@ -33,7 +33,7 @@ func joinHistoricalFeatures(ctx context.Context, store *oomstore.OomStore, opt J
 	}
 
 	joinResult, err := store.GetHistoricalFeatureValues(ctx, types.GetHistoricalFeatureValuesOpt{
-		FeatureIDs: features.Ids(),
+		FeatureIDs: features.IDs(),
 		EntityRows: entityRows,
 	})
 	if err != nil {

--- a/featctl/cmd/sync.go
+++ b/featctl/cmd/sync.go
@@ -31,6 +31,6 @@ func init() {
 
 	flags := syncCmd.Flags()
 
-	flags.IntVarP(&syncOpt.RevisionId, "revision-id", "r", 0, "group revision id")
+	flags.IntVarP(&syncOpt.RevisionID, "revision-id", "r", 0, "group revision id")
 	_ = syncCmd.MarkFlagRequired("revision-id")
 }

--- a/internal/database/metadata/postgres/db.go
+++ b/internal/database/metadata/postgres/db.go
@@ -32,15 +32,15 @@ func (db *DB) UpdateFeature(ctx context.Context, opt metadata.UpdateFeatureOpt) 
 
 func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (int, string, error) {
 	var (
-		revisionId int
+		revisionID int
 		dataTable  string
 		err        error
 	)
 	err = db.WithTransaction(ctx, func(c context.Context, s metadata.Store) error {
-		revisionId, dataTable, err = createRevision(ctx, db, opt)
+		revisionID, dataTable, err = createRevision(ctx, db, opt)
 		return err
 	})
-	return revisionId, dataTable, err
+	return revisionID, dataTable, err
 }
 
 func (db *DB) UpdateRevision(ctx context.Context, opt metadata.UpdateRevisionOpt) error {

--- a/internal/database/metadata/postgres/entity.go
+++ b/internal/database/metadata/postgres/entity.go
@@ -10,15 +10,15 @@ import (
 )
 
 func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateEntityOpt) (int, error) {
-	var entityId int
+	var entityID int
 	query := "insert into feature_entity(name, length, description) values($1, $2, $3) returning id"
-	err := sqlxCtx.GetContext(ctx, &entityId, query, opt.EntityName, opt.Length, opt.Description)
+	err := sqlxCtx.GetContext(ctx, &entityID, query, opt.EntityName, opt.Length, opt.Description)
 	if er, ok := err.(*pq.Error); ok {
 		if er.Code == pgerrcode.UniqueViolation {
 			return 0, fmt.Errorf("entity %s already exists", opt.EntityName)
 		}
 	}
-	return entityId, err
+	return entityID, err
 }
 
 func updateEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.UpdateEntityOpt) error {

--- a/internal/database/metadata/postgres/feature.go
+++ b/internal/database/metadata/postgres/feature.go
@@ -14,9 +14,9 @@ func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metada
 	if err := validateDataType(ctx, sqlxCtx, opt.DBValueType); err != nil {
 		return 0, fmt.Errorf("err when validating value_type input, details: %s", err.Error())
 	}
-	var featureId int
+	var featureID int
 	query := "INSERT INTO feature(name, group_id, db_value_type, value_type, description) VALUES ($1, $2, $3, $4, $5) RETURNING id"
-	err := sqlxCtx.GetContext(ctx, &featureId, query, opt.FeatureName, opt.GroupID, opt.DBValueType, opt.ValueType, opt.Description)
+	err := sqlxCtx.GetContext(ctx, &featureID, query, opt.FeatureName, opt.GroupID, opt.DBValueType, opt.ValueType, opt.Description)
 	if err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
@@ -24,7 +24,7 @@ func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metada
 			}
 		}
 	}
-	return featureId, err
+	return featureID, err
 }
 
 func updateFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.UpdateFeatureOpt) error {

--- a/internal/database/metadata/postgres/feature_group.go
+++ b/internal/database/metadata/postgres/feature_group.go
@@ -16,9 +16,9 @@ func createFeatureGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt m
 	if opt.Category != types.BatchFeatureCategory && opt.Category != types.StreamFeatureCategory {
 		return 0, fmt.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category)
 	}
-	var featureGroupId int
+	var featureGroupID int
 	query := "insert into feature_group(name, entity_id, category, description) values($1, $2, $3, $4) returning id"
-	err := sqlxCtx.GetContext(ctx, &featureGroupId, query, opt.Name, opt.EntityID, opt.Category, opt.Description)
+	err := sqlxCtx.GetContext(ctx, &featureGroupID, query, opt.Name, opt.EntityID, opt.Category, opt.Description)
 	if err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
@@ -26,7 +26,7 @@ func createFeatureGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt m
 			}
 		}
 	}
-	return featureGroupId, err
+	return featureGroupID, err
 }
 
 func updateFeatureGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.UpdateFeatureGroupOpt) error {

--- a/internal/database/metadata/postgres/revision.go
+++ b/internal/database/metadata/postgres/revision.go
@@ -17,20 +17,20 @@ func createRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metad
 		dataTable = *opt.DataTable
 	}
 
-	var revisionId int
+	var revisionID int
 	insertQuery := "INSERT INTO feature_group_revision(group_id, revision, data_table, anchored, description) VALUES ($1, $2, $3, $4, $5) RETURNING id"
-	if err := sqlxCtx.GetContext(ctx, &revisionId, insertQuery, opt.GroupID, opt.Revision, dataTable, opt.Anchored, opt.Description); err != nil {
+	if err := sqlxCtx.GetContext(ctx, &revisionID, insertQuery, opt.GroupID, opt.Revision, dataTable, opt.Anchored, opt.Description); err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
-				return 0, "", fmt.Errorf("revision already exists: groupId=%d, revision=%d", opt.GroupID, opt.Revision)
+				return 0, "", fmt.Errorf("revision already exists: groupID=%d, revision=%d", opt.GroupID, opt.Revision)
 			}
 		}
 		return 0, "", err
 	}
 	if opt.DataTable == nil {
 		updateQuery := "UPDATE feature_group_revision SET data_table = $1 WHERE id = $2"
-		dataTable = fmt.Sprintf("data_%d_%d", opt.GroupID, revisionId)
-		result, err := sqlxCtx.ExecContext(ctx, updateQuery, dataTable, revisionId)
+		dataTable = fmt.Sprintf("data_%d_%d", opt.GroupID, revisionID)
+		result, err := sqlxCtx.ExecContext(ctx, updateQuery, dataTable, revisionID)
 		if err != nil {
 			return 0, "", err
 		}
@@ -39,11 +39,11 @@ func createRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metad
 			return 0, "", err
 		}
 		if rowsAffected != 1 {
-			return 0, "", fmt.Errorf("failed to update revision %d: revision not found", revisionId)
+			return 0, "", fmt.Errorf("failed to update revision %d: revision not found", revisionID)
 		}
 	}
 
-	return revisionId, dataTable, nil
+	return revisionID, dataTable, nil
 }
 
 // UpdateRevision = MustUpdateRevision

--- a/internal/database/metadata/test_impl/feature_group.go
+++ b/internal/database/metadata/test_impl/feature_group.go
@@ -11,7 +11,7 @@ import (
 )
 
 func prepareEntity(t *testing.T, ctx context.Context, store metadata.Store, name string) int {
-	entityId, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
+	entityID, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
 		CreateEntityOpt: types.CreateEntityOpt{
 			EntityName:  name,
 			Length:      32,
@@ -19,18 +19,18 @@ func prepareEntity(t *testing.T, ctx context.Context, store metadata.Store, name
 		},
 	})
 	require.NoError(t, err)
-	return entityId
+	return entityID
 }
 
 func TestGetFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	entityId := prepareEntity(t, ctx, store, "device")
+	entityID := prepareEntity(t, ctx, store, "device")
 
 	opt := metadata.CreateFeatureGroupOpt{
 		Name:        "device_baseinfo",
-		EntityID:    entityId,
+		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
@@ -56,24 +56,24 @@ func TestListFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	deviceEntityId := prepareEntity(t, ctx, store, "device")
-	userEntityId := prepareEntity(t, ctx, store, "user")
+	deviceEntityID := prepareEntity(t, ctx, store, "device")
+	userEntityID := prepareEntity(t, ctx, store, "user")
 
 	deviceOpt := metadata.CreateFeatureGroupOpt{
 		Name:        "device_baseinfo",
-		EntityID:    deviceEntityId,
+		EntityID:    deviceEntityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
 	userBaseOpt := metadata.CreateFeatureGroupOpt{
 		Name:        "user_baseinfo",
-		EntityID:    userEntityId,
+		EntityID:    userEntityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
 	userBehaviorOpt := metadata.CreateFeatureGroupOpt{
 		Name:        "user_behaviorinfo",
-		EntityID:    userEntityId,
+		EntityID:    userEntityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
@@ -96,18 +96,18 @@ func TestCreateFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) 
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	entityId := prepareEntity(t, ctx, store, "device")
+	entityID := prepareEntity(t, ctx, store, "device")
 
 	opt := metadata.CreateFeatureGroupOpt{
 		Name:        "device_baseinfo",
-		EntityID:    entityId,
+		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
 
 	// create successfully
-	featureGroupId, err := store.CreateFeatureGroup(ctx, opt)
-	require.NotEqual(t, 0, featureGroupId)
+	featureGroupID, err := store.CreateFeatureGroup(ctx, opt)
+	require.NotEqual(t, 0, featureGroupID)
 	require.NoError(t, err)
 
 	// cannot create feature group with same name
@@ -124,15 +124,15 @@ func TestUpdateFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) 
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	entityId := prepareEntity(t, ctx, store, "device")
+	entityID := prepareEntity(t, ctx, store, "device")
 
 	opt := metadata.CreateFeatureGroupOpt{
 		Name:        "device_baseinfo",
-		EntityID:    entityId,
+		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
-	featureGroupId, err := store.CreateFeatureGroup(ctx, opt)
+	featureGroupID, err := store.CreateFeatureGroup(ctx, opt)
 	require.NoError(t, err)
 
 	// update non-exist feature group
@@ -143,7 +143,7 @@ func TestUpdateFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) 
 	// update existing feature group
 	description := "new description"
 	require.Nil(t, store.UpdateFeatureGroup(ctx, metadata.UpdateFeatureGroupOpt{
-		GroupID:        featureGroupId,
+		GroupID:        featureGroupID,
 		NewDescription: &description,
 	}))
 }

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -16,11 +16,11 @@ func TestCreateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	_, groupId := prepareEntityAndGroup(t, ctx, store)
-	group, err := store.GetFeatureGroup(ctx, groupId)
+	_, groupID := prepareEntityAndGroup(t, ctx, store)
+	group, err := store.GetFeatureGroup(ctx, groupID)
 	require.NoError(t, err)
 	opt := metadata.CreateRevisionOpt{
-		GroupID:     groupId,
+		GroupID:     groupID,
 		Revision:    1000,
 		DataTable:   stringPtr("device_info_20211028"),
 		Description: "description",
@@ -44,14 +44,14 @@ func TestCreateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 				DataTable:   "device_info_20211028",
 				Anchored:    false,
 				Description: "description",
-				GroupID:     groupId,
+				GroupID:     groupID,
 				Group:       group,
 			},
 		},
 		{
 			description: "create revision without data table, use default data table name",
 			opt: metadata.CreateRevisionOpt{
-				GroupID:     groupId,
+				GroupID:     groupID,
 				Revision:    2000,
 				Description: "description",
 			},
@@ -63,14 +63,14 @@ func TestCreateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 				DataTable:   "data_1_2",
 				Anchored:    false,
 				Description: "description",
-				GroupID:     groupId,
+				GroupID:     groupID,
 				Group:       group,
 			},
 		},
 		{
 			description:   "create existing revision, return error",
 			opt:           opt,
-			expectedError: fmt.Errorf("revision already exists: groupId=%d, revision=1000", groupId),
+			expectedError: fmt.Errorf("revision already exists: groupID=%d, revision=1000", groupID),
 			expected:      0,
 		},
 	}
@@ -97,10 +97,10 @@ func TestUpdateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	_, groupId := prepareEntityAndGroup(t, ctx, store)
-	revisionId, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
+	_, groupID := prepareEntityAndGroup(t, ctx, store)
+	revisionID, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: stringPtr("device_info_1000"),
 		Anchored:  false,
 	})
@@ -114,7 +114,7 @@ func TestUpdateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		{
 			description: "update revision successfully",
 			opt: metadata.UpdateRevisionOpt{
-				RevisionID:  revisionId,
+				RevisionID:  revisionID,
 				NewAnchored: boolPtr(true),
 			},
 			expected: nil,
@@ -122,10 +122,10 @@ func TestUpdateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		{
 			description: "cannot update revision, return err",
 			opt: metadata.UpdateRevisionOpt{
-				RevisionID:  revisionId - 1,
+				RevisionID:  revisionID - 1,
 				NewAnchored: boolPtr(true),
 			},
-			expected: fmt.Errorf("failed to update revision %d: revision not found", revisionId-1),
+			expected: fmt.Errorf("failed to update revision %d: revision not found", revisionID-1),
 		},
 	}
 
@@ -145,23 +145,23 @@ func TestGetRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	_, groupId := prepareEntityAndGroup(t, ctx, store)
-	revisionId, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
+	_, groupID := prepareEntityAndGroup(t, ctx, store)
+	revisionID, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: stringPtr("device_info_1000"),
 		Anchored:  false,
 	})
 	require.NoError(t, err)
 
 	require.NoError(t, store.Refresh())
-	group, err := store.GetFeatureGroup(ctx, groupId)
+	group, err := store.GetFeatureGroup(ctx, groupID)
 	require.NoError(t, err)
 
 	revision := types.Revision{
-		ID:        revisionId,
+		ID:        revisionID,
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: "device_info_1000",
 		Anchored:  false,
 		Group:     group,
@@ -174,8 +174,8 @@ func TestGetRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		expected      *types.Revision
 	}{
 		{
-			description:   "get revision by revisionId successfully",
-			revisionID:    revisionId,
+			description:   "get revision by revisionID successfully",
+			revisionID:    revisionID,
 			expectedError: nil,
 			expected:      &revision,
 		},
@@ -207,23 +207,23 @@ func TestGetRevisionBy(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	_, groupId := prepareEntityAndGroup(t, ctx, store)
-	revisionId, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
+	_, groupID := prepareEntityAndGroup(t, ctx, store)
+	revisionID, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: stringPtr("device_info_1000"),
 		Anchored:  false,
 	})
 	require.NoError(t, err)
 
 	require.NoError(t, store.Refresh())
-	group, err := store.GetFeatureGroup(ctx, groupId)
+	group, err := store.GetFeatureGroup(ctx, groupID)
 	require.NoError(t, err)
 
 	revision := types.Revision{
-		ID:        revisionId,
+		ID:        revisionID,
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: "device_info_1000",
 		Anchored:  false,
 		Group:     group,
@@ -239,14 +239,14 @@ func TestGetRevisionBy(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	}{
 		{
 			description:   "get revision by groupID and revision successfully",
-			GroupID:       groupId,
+			GroupID:       groupID,
 			Revision:      revision.Revision,
 			expectedError: nil,
 			expected:      &revision,
 		},
 		{
 			description:   "try to get not existed revision, return error",
-			GroupID:       groupId,
+			GroupID:       groupID,
 			Revision:      0,
 			expectedError: fmt.Errorf("revision not found"),
 			expected:      nil,
@@ -280,7 +280,7 @@ func TestListRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	_, groupId, _, revisions := prepareRevisions(t, ctx, store)
+	_, groupID, _, revisions := prepareRevisions(t, ctx, store)
 	var nilRevisionList types.RevisionList
 	require.NoError(t, store.Refresh())
 
@@ -292,7 +292,7 @@ func TestListRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		{
 			description: "list revision by groupID, succeed",
 			opt: metadata.ListRevisionOpt{
-				GroupID: &groupId,
+				GroupID: &groupID,
 			},
 			expected: revisions,
 		},
@@ -314,7 +314,7 @@ func TestListRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 			description: "list revision by empty dataTables, return empty list",
 			opt: metadata.ListRevisionOpt{
 				DataTables: []string{},
-				GroupID:    &groupId,
+				GroupID:    &groupID,
 			},
 			expected: nilRevisionList,
 		},
@@ -351,7 +351,7 @@ func prepareRevisions(t *testing.T, ctx context.Context, store metadata.Store) (
 	})
 	require.NoError(t, err)
 
-	groupId, err := store.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
+	groupID, err := store.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
 		Name:        "device_info",
 		EntityID:    entityID,
 		Description: "description",
@@ -359,43 +359,43 @@ func prepareRevisions(t *testing.T, ctx context.Context, store metadata.Store) (
 	})
 	require.NoError(t, err)
 	require.NoError(t, store.Refresh())
-	revisionId1, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
+	revisionID1, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: stringPtr("device_info_1000"),
 		Anchored:  false,
 	})
 	require.NoError(t, err)
 
-	revisionId2, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
+	revisionID2, _, err := store.CreateRevision(ctx, metadata.CreateRevisionOpt{
 		Revision:  2000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: stringPtr("device_info_2000"),
 		Anchored:  false,
 	})
 	require.NoError(t, err)
 
 	require.NoError(t, store.Refresh())
-	group, err := store.GetFeatureGroup(ctx, groupId)
+	group, err := store.GetFeatureGroup(ctx, groupID)
 	require.NoError(t, err)
 
 	revision1 := &types.Revision{
-		ID:        revisionId1,
+		ID:        revisionID1,
 		Revision:  1000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: "device_info_1000",
 		Anchored:  false,
 		Group:     group,
 	}
 
 	revision2 := &types.Revision{
-		ID:        revisionId2,
+		ID:        revisionID2,
 		Revision:  2000,
-		GroupID:   groupId,
+		GroupID:   groupID,
 		DataTable: "device_info_2000",
 		Anchored:  false,
 		Group:     group,
 	}
 
-	return entityID, groupId, []int{revisionId1, revisionId2}, types.RevisionList{revision1, revision2}
+	return entityID, groupID, []int{revisionID1, revisionID2}, types.RevisionList{revision1, revision2}
 }

--- a/internal/database/online/postgres/import.go
+++ b/internal/database/online/postgres/import.go
@@ -57,6 +57,6 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 	return err
 }
 
-func getOnlineBatchTableName(revisionId int) string {
-	return fmt.Sprintf("batch_%d", revisionId)
+func getOnlineBatchTableName(revisionID int) string {
+	return fmt.Sprintf("batch_%d", revisionID)
 }

--- a/internal/database/online/redis/get.go
+++ b/internal/database/online/redis/get.go
@@ -13,16 +13,16 @@ func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error)
 		return nil, err
 	}
 
-	featureIds := []string{}
+	featureIDs := []string{}
 	for _, f := range opt.FeatureList {
 		id, err := SerializeByValue(f.ID)
 		if err != nil {
 			return nil, err
 		}
-		featureIds = append(featureIds, id)
+		featureIDs = append(featureIDs, id)
 	}
 
-	values, err := db.HMGet(ctx, key, featureIds...).Result()
+	values, err := db.HMGet(ctx, key, featureIDs...).Result()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/online/redis/import.go
+++ b/internal/database/online/redis/import.go
@@ -39,11 +39,11 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 				return err
 			}
 
-			featureId, err := SerializeByValue(opt.FeatureList[i].ID)
+			featureID, err := SerializeByValue(opt.FeatureList[i].ID)
 			if err != nil {
 				return err
 			}
-			featureValues[featureId] = featureValue
+			featureValues[featureID] = featureValue
 		}
 
 		pipe.HSet(ctx, key, featureValues)

--- a/internal/database/online/redis/util.go
+++ b/internal/database/online/redis/util.go
@@ -127,8 +127,8 @@ func DeserializeByTag(i interface{}, typeTag string) (interface{}, error) {
 	}
 }
 
-func SerializeRedisKey(revisionId int, entityKey interface{}) (string, error) {
-	prefix, err := SerializeByValue(revisionId)
+func SerializeRedisKey(revisionID int, entityKey interface{}) (string, error) {
+	prefix, err := SerializeByValue(revisionID)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/oomstore/join_test.go
+++ b/pkg/oomstore/join_test.go
@@ -57,7 +57,7 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "no valid features, return nil",
 			opt: types.GetHistoricalFeatureValuesOpt{
-				FeatureIDs: streamFeatures.Ids(),
+				FeatureIDs: streamFeatures.IDs(),
 				EntityRows: entityRows,
 			},
 			features:      streamFeatures,
@@ -67,7 +67,7 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "inconsistent features, return nil",
 			opt: types.GetHistoricalFeatureValuesOpt{
-				FeatureIDs: inconsistentFeatures.Ids(),
+				FeatureIDs: inconsistentFeatures.IDs(),
 				EntityRows: entityRows,
 			},
 			features:      inconsistentFeatures,
@@ -77,7 +77,7 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "nil joined, return nil",
 			opt: types.GetHistoricalFeatureValuesOpt{
-				FeatureIDs: consistentFeatures.Ids(),
+				FeatureIDs: consistentFeatures.IDs(),
 				EntityRows: entityRows,
 			},
 			entity:   &entity,
@@ -93,7 +93,7 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "consistent entity type, succeed",
 			opt: types.GetHistoricalFeatureValuesOpt{
-				FeatureIDs: consistentFeatures.Ids(),
+				FeatureIDs: consistentFeatures.IDs(),
 				EntityRows: entityRows,
 			},
 			entity:   &entity,

--- a/pkg/oomstore/online_query.go
+++ b/pkg/oomstore/online_query.go
@@ -31,15 +31,15 @@ func (s *OomStore) GetOnlineFeatureValues(ctx context.Context, opt types.GetOnli
 		return &rs, nil
 	}
 
-	featureMap := groupFeaturesByRevisionId(features)
+	featureMap := groupFeaturesByRevisionID(features)
 
-	for onlineRevisionId, features := range featureMap {
+	for onlineRevisionID, features := range featureMap {
 		if len(features) == 0 {
 			continue
 		}
 		featureValues, err := s.online.Get(ctx, online.GetOpt{
 			Entity:      entity,
-			RevisionID:  onlineRevisionId,
+			RevisionID:  onlineRevisionID,
 			EntityKey:   opt.EntityKey,
 			FeatureList: features,
 		})
@@ -70,7 +70,7 @@ func (s *OomStore) MultiGetOnlineFeatureValues(ctx context.Context, opt types.Mu
 	if entity == nil {
 		return nil, fmt.Errorf("failed to get shared entity")
 	}
-	featureMap := groupFeaturesByRevisionId(features)
+	featureMap := groupFeaturesByRevisionID(features)
 
 	// entity_key -> feature_name -> feature_value
 	featureValueMap, err := s.getFeatureValueMap(ctx, opt.EntityKeys, featureMap, entity)
@@ -85,13 +85,13 @@ func (s *OomStore) getFeatureValueMap(ctx context.Context, entityKeys []string, 
 	// entity_key -> types.RecordMap
 	featureValueMap := make(map[string]dbutil.RowMap)
 
-	for onlineRevisionId, features := range featureMap {
+	for onlineRevisionID, features := range featureMap {
 		if len(features) == 0 {
 			continue
 		}
 		featureValues, err := s.online.MultiGet(ctx, online.MultiGetOpt{
 			Entity:      entity,
-			RevisionID:  onlineRevisionId,
+			RevisionID:  onlineRevisionID,
 			EntityKeys:  entityKeys,
 			FeatureList: features,
 		})
@@ -110,7 +110,7 @@ func (s *OomStore) getFeatureValueMap(ctx context.Context, entityKeys []string, 
 	return featureValueMap, nil
 }
 
-func groupFeaturesByRevisionId(features types.FeatureList) map[int]types.FeatureList {
+func groupFeaturesByRevisionID(features types.FeatureList) map[int]types.FeatureList {
 	featureMap := make(map[int]types.FeatureList)
 	for _, f := range features {
 		id := f.OnlineRevisionID()

--- a/pkg/oomstore/online_query_test.go
+++ b/pkg/oomstore/online_query_test.go
@@ -127,7 +127,7 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 		{
 			description: "no available features, return nil",
 			opt: types.MultiGetOnlineFeatureValuesOpt{
-				FeatureIDs: unavailableFeatures.Ids(),
+				FeatureIDs: unavailableFeatures.IDs(),
 				EntityKeys: []string{"1234", "1235"},
 			},
 			features:      unavailableFeatures,
@@ -137,7 +137,7 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 		{
 			description: "inconsistent entity type, fail",
 			opt: types.MultiGetOnlineFeatureValuesOpt{
-				FeatureIDs: inconsistentFeatures.Ids(),
+				FeatureIDs: inconsistentFeatures.IDs(),
 				EntityKeys: []string{"1234", "1235"},
 			},
 			features:      inconsistentFeatures,
@@ -147,7 +147,7 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 		{
 			description: "consistent entity type, succeed",
 			opt: types.MultiGetOnlineFeatureValuesOpt{
-				FeatureIDs: consistentFeatures.Ids(),
+				FeatureIDs: consistentFeatures.IDs(),
 				EntityKeys: []string{"1234", "1235"},
 			},
 			features:      consistentFeatures,

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -13,14 +13,14 @@ import (
 
 // Move a certain feature group revision data from offline to online store
 func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
-	revision, err := s.GetRevision(ctx, opt.RevisionId)
+	revision, err := s.GetRevision(ctx, opt.RevisionID)
 	if err != nil {
 		return err
 	}
 
 	group := revision.Group
 	prevOnlineRevisionID := group.OnlineRevisionID
-	if prevOnlineRevisionID != nil && *prevOnlineRevisionID == opt.RevisionId {
+	if prevOnlineRevisionID != nil && *prevOnlineRevisionID == opt.RevisionID {
 		return fmt.Errorf("the specific revision was synced to the online store, won't do it again this time")
 	}
 

--- a/pkg/oomstore/sync_test.go
+++ b/pkg/oomstore/sync_test.go
@@ -45,7 +45,7 @@ func TestSync(t *testing.T) {
 		{
 			description: "the specific revision was synced to the online store, won't do it again this time",
 			opt: types.SyncOpt{
-				RevisionId: 1,
+				RevisionID: 1,
 			},
 			expectedError: fmt.Errorf("the specific revision was synced to the online store, won't do it again this time"),
 			mockFn: func() {
@@ -61,7 +61,7 @@ func TestSync(t *testing.T) {
 		{
 			description: "no previous revision, succeed",
 			opt: types.SyncOpt{
-				RevisionId: 1,
+				RevisionID: 1,
 			},
 			expectedError: nil,
 			mockFn: func() {
@@ -100,7 +100,7 @@ func TestSync(t *testing.T) {
 		{
 			description: "purge previous revision, succeed",
 			opt: types.SyncOpt{
-				RevisionId: 1,
+				RevisionID: 1,
 			},
 			expectedError: nil,
 			mockFn: func() {

--- a/pkg/oomstore/types/feature.go
+++ b/pkg/oomstore/types/feature.go
@@ -62,7 +62,7 @@ func (l *FeatureList) Names() (names []string) {
 	return
 }
 
-func (l *FeatureList) Ids() (ids []int) {
+func (l *FeatureList) IDs() (ids []int) {
 	for _, f := range *l {
 		ids = append(ids, f.ID)
 	}

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -75,15 +75,15 @@ type UpdateEntityOpt struct {
 type UpdateFeatureGroupOpt struct {
 	GroupName        string
 	Description      *string
-	OnlineRevisionId *int
+	OnlineRevisionID *int
 }
 
 type SyncOpt struct {
-	RevisionId int
+	RevisionID int
 }
 
 type GetRevisionOpt struct {
 	GroupName  *string
 	Revision   *int64
-	RevisionId *int
+	RevisionID *int
 }


### PR DESCRIPTION
This pr changes `Id` into `ID` everywhere.

Close #502  