### PR TITLE
Jinghan/use types.CreateFeatureGroupOpt and types.UpdateFeatureGroupOpt in oomstore #506

### DIFF
--- a/featctl/cmd/register_group.go
+++ b/featctl/cmd/register_group.go
@@ -4,36 +4,24 @@ import (
 	"context"
 	"log"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
 )
 
-type registerGroupOption struct {
-	metadata.CreateFeatureGroupOpt
-	entityName string
-}
-
-var registerGroupOpt registerGroupOption
-
+var registerGroupOpt types.CreateFeatureGroupOpt
 var registerGroupCmd = &cobra.Command{
 	Use:   "group",
 	Short: "register a new feature group",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
-		registerGroupOpt.Name = args[0]
+		registerGroupOpt.GroupName = args[0]
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		entity, err := oomStore.GetEntityByName(ctx, registerGroupOpt.entityName)
-		if err != nil {
-			log.Fatalf("failed to get entity name='%s': %v", registerGroupOpt.entityName, err)
-		}
-		registerGroupOpt.EntityID = entity.ID
-
-		if _, err := oomStore.CreateFeatureGroup(ctx, registerGroupOpt.CreateFeatureGroupOpt); err != nil {
+		if _, err := oomStore.CreateFeatureGroup(ctx, registerGroupOpt); err != nil {
 			log.Fatalf("failed registering new group: %v\n", err)
 		}
 	},
@@ -44,7 +32,7 @@ func init() {
 
 	flags := registerGroupCmd.Flags()
 
-	flags.StringVarP(&registerGroupOpt.entityName, "entity", "e", "", "entity name")
+	flags.StringVarP(&registerGroupOpt.EntityName, "entity", "e", "", "entity name")
 	_ = registerGroupCmd.MarkFlagRequired("entity")
 
 	flags.StringVarP(&registerGroupOpt.Description, "description", "d", "", "group description")

--- a/featctl/cmd/update_group.go
+++ b/featctl/cmd/update_group.go
@@ -4,30 +4,26 @@ import (
 	"context"
 	"log"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
 )
 
-var updateGroupOpt metadata.UpdateFeatureGroupOpt
+var updateGroupOpt types.UpdateFeatureGroupOpt
 
 var updateGroupCmd = &cobra.Command{
 	Use:   "group",
 	Short: "update a specified group",
 	Args:  cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		updateGroupOpt.GroupName = args[0]
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		groupName := args[0]
-		group, err := oomStore.GetFeatureGroupByName(ctx, groupName)
-		if err != nil {
-			log.Fatalf("failed to get feature group name=%s: %v", groupName, err)
-		}
-		updateGroupOpt.GroupID = group.ID
-
 		if err := oomStore.UpdateFeatureGroup(ctx, updateGroupOpt); err != nil {
-			log.Fatalf("failed updating group %d, err %v\n", group.ID, err)
+			log.Fatalf("failed updating group %s, err %v\n", updateGroupOpt.GroupName, err)
 		}
 	},
 }

--- a/internal/database/metadata/postgres/feature_group.go
+++ b/internal/database/metadata/postgres/feature_group.go
@@ -18,11 +18,11 @@ func createFeatureGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt m
 	}
 	var featureGroupID int
 	query := "insert into feature_group(name, entity_id, category, description) values($1, $2, $3, $4) returning id"
-	err := sqlxCtx.GetContext(ctx, &featureGroupID, query, opt.Name, opt.EntityID, opt.Category, opt.Description)
+	err := sqlxCtx.GetContext(ctx, &featureGroupID, query, opt.GroupName, opt.EntityID, opt.Category, opt.Description)
 	if err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
-				return 0, fmt.Errorf("feature group %s already exists", opt.Name)
+				return 0, fmt.Errorf("feature group %s already exists", opt.GroupName)
 			}
 		}
 	}

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -22,7 +22,7 @@ func prepareEntityAndGroup(t *testing.T, ctx context.Context, store metadata.Sto
 	require.NoError(t, err)
 
 	groupID, err := store.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
-		Name:        "device_info",
+		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,

--- a/internal/database/metadata/test_impl/feature_group.go
+++ b/internal/database/metadata/test_impl/feature_group.go
@@ -29,7 +29,7 @@ func TestGetFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	entityID := prepareEntity(t, ctx, store, "device")
 
 	opt := metadata.CreateFeatureGroupOpt{
-		Name:        "device_baseinfo",
+		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
@@ -46,7 +46,7 @@ func TestGetFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	// get existing feature group
 	featureGroup, err := store.GetFeatureGroup(ctx, id)
 	require.NoError(t, err)
-	require.Equal(t, opt.Name, featureGroup.Name)
+	require.Equal(t, opt.GroupName, featureGroup.Name)
 	require.Equal(t, opt.EntityID, featureGroup.EntityID)
 	require.Equal(t, opt.Description, featureGroup.Description)
 	require.Equal(t, opt.Category, featureGroup.Category)
@@ -60,19 +60,19 @@ func TestListFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	userEntityID := prepareEntity(t, ctx, store, "user")
 
 	deviceOpt := metadata.CreateFeatureGroupOpt{
-		Name:        "device_baseinfo",
+		GroupName:   "device_info",
 		EntityID:    deviceEntityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
 	userBaseOpt := metadata.CreateFeatureGroupOpt{
-		Name:        "user_baseinfo",
+		GroupName:   "user_info",
 		EntityID:    userEntityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
 	}
 	userBehaviorOpt := metadata.CreateFeatureGroupOpt{
-		Name:        "user_behaviorinfo",
+		GroupName:   "user_profile",
 		EntityID:    userEntityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
@@ -99,7 +99,7 @@ func TestCreateFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) 
 	entityID := prepareEntity(t, ctx, store, "device")
 
 	opt := metadata.CreateFeatureGroupOpt{
-		Name:        "device_baseinfo",
+		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,
@@ -112,7 +112,7 @@ func TestCreateFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) 
 
 	// cannot create feature group with same name
 	_, err = store.CreateFeatureGroup(ctx, opt)
-	require.Equal(t, fmt.Errorf("feature group device_baseinfo already exists"), err)
+	require.Equal(t, fmt.Errorf("feature group device_info already exists"), err)
 
 	// cannot create feature group with invalid category
 	opt.Category = "invalid-category"
@@ -127,7 +127,7 @@ func TestUpdateFeatureGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) 
 	entityID := prepareEntity(t, ctx, store, "device")
 
 	opt := metadata.CreateFeatureGroupOpt{
-		Name:        "device_baseinfo",
+		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -352,7 +352,7 @@ func prepareRevisions(t *testing.T, ctx context.Context, store metadata.Store) (
 	require.NoError(t, err)
 
 	groupID, err := store.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
-		Name:        "device_info",
+		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
 		Category:    types.BatchFeatureCategory,

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -19,7 +19,7 @@ type CreateFeatureOpt struct {
 }
 
 type CreateFeatureGroupOpt struct {
-	Name        string
+	GroupName   string
 	EntityID    int
 	Description string
 	Category    string

--- a/pkg/oomstore/feature_group.go
+++ b/pkg/oomstore/feature_group.go
@@ -34,6 +34,14 @@ func (s *OomStore) ListFeatureGroup(ctx context.Context, entityID *int) types.Fe
 	return s.metadata.ListFeatureGroup(ctx, entityID)
 }
 
-func (s *OomStore) UpdateFeatureGroup(ctx context.Context, opt metadata.UpdateFeatureGroupOpt) error {
-	return s.metadata.UpdateFeatureGroup(ctx, opt)
+func (s *OomStore) UpdateFeatureGroup(ctx context.Context, opt types.UpdateFeatureGroupOpt) error {
+	group, err := s.metadata.GetFeatureGroupByName(ctx, opt.GroupName)
+	if err != nil {
+		return err
+	}
+	return s.metadata.UpdateFeatureGroup(ctx, metadata.UpdateFeatureGroupOpt{
+		GroupID:             group.ID,
+		NewDescription:      opt.NewDescription,
+		NewOnlineRevisionID: opt.NewOnlineRevisionID,
+	})
 }

--- a/pkg/oomstore/feature_group.go
+++ b/pkg/oomstore/feature_group.go
@@ -7,11 +7,19 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func (s *OomStore) CreateFeatureGroup(ctx context.Context, opt metadata.CreateFeatureGroupOpt) (int, error) {
-	// Via the oomstore API, we can only create a batch feature group
-	// So we hardcode the category to be batch
-	opt.Category = types.BatchFeatureCategory
-	return s.metadata.CreateFeatureGroup(ctx, opt)
+func (s *OomStore) CreateFeatureGroup(ctx context.Context, opt types.CreateFeatureGroupOpt) (int, error) {
+	entity, err := s.metadata.GetEntityByName(ctx, opt.EntityName)
+	if err != nil {
+		return 0, err
+	}
+	return s.metadata.CreateFeatureGroup(ctx, metadata.CreateFeatureGroupOpt{
+		GroupName:   opt.GroupName,
+		EntityID:    entity.ID,
+		Description: opt.Description,
+		// Via the oomstore API, we can only create a batch feature group
+		// So we hardcode the category to be batch
+		Category: types.BatchFeatureCategory,
+	})
 }
 
 func (s *OomStore) GetFeatureGroup(ctx context.Context, id int) (*types.FeatureGroup, error) {

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -29,7 +29,7 @@ type CreateEntityOpt struct {
 }
 
 type CreateFeatureGroupOpt struct {
-	Name        string
+	GroupName   string
 	EntityName  string
 	Description string
 }

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -73,9 +73,9 @@ type UpdateEntityOpt struct {
 }
 
 type UpdateFeatureGroupOpt struct {
-	GroupName        string
-	Description      *string
-	OnlineRevisionID *int
+	GroupName           string
+	NewDescription      *string
+	NewOnlineRevisionID *int
 }
 
 type SyncOpt struct {


### PR DESCRIPTION
This PR does:
- separate `types.CreateFeatureGroupOpt` and `metadata.CreateFeatureGroupOpt`
- separate `types.UpdateFeatureGroupOpt` and `metadata.UpdateFeatureGroupOpt`

related to #490 