### PR TITLE
Jinghan/remove GetRevisionOpt

### DIFF
--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -231,7 +231,6 @@ func TestGetRevisionBy(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 
 	testCases := []struct {
 		description   string
-		opt           metadata.GetRevisionOpt
 		GroupID       int
 		Revision      int64
 		expectedError error

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -56,13 +56,6 @@ type UpdateRevisionOpt struct {
 	NewAnchored *bool
 }
 
-// Get
-type GetRevisionOpt struct {
-	GroupID    *int
-	Revision   *int64
-	RevisionID *int
-}
-
 // List
 type ListRevisionOpt struct {
 	GroupID    *int

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -81,9 +81,3 @@ type UpdateFeatureGroupOpt struct {
 type SyncOpt struct {
 	RevisionID int
 }
-
-type GetRevisionOpt struct {
-	GroupName  *string
-	Revision   *int64
-	RevisionID *int
-}


### PR DESCRIPTION
This PR removes `metadata.GetRevisionOpt` and `types.GetRevisionOpt`.

related to #490 