### PR TITLE
refactor: simplify list revision opt

### DIFF
--- a/internal/database/metadata/informer/informer.go
+++ b/internal/database/metadata/informer/informer.go
@@ -186,6 +186,6 @@ func (f *Informer) ListFeatureGroup(ctx context.Context, entityID *int) types.Fe
 	return f.Cache().Groups.List(entityID).Copy()
 }
 
-func (f *Informer) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) types.RevisionList {
-	return f.Cache().Revisions.List(opt).Copy()
+func (f *Informer) ListRevision(ctx context.Context, groupID *int) types.RevisionList {
+	return f.Cache().Revisions.List(groupID).Copy()
 }

--- a/internal/database/metadata/informer/revision.go
+++ b/internal/database/metadata/informer/revision.go
@@ -1,7 +1,6 @@
 package informer
 
 import (
-	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -17,24 +16,11 @@ func (c *RevisionCache) Enrich(groupCache *GroupCache) {
 	}
 }
 
-func (c *RevisionCache) List(opt metadata.ListRevisionOpt) types.RevisionList {
-	var revisions types.RevisionList
-	if opt.DataTables != nil {
-		for _, table := range opt.DataTables {
-			if r := c.Find(func(r *types.Revision) bool {
-				return r.DataTable == table
-			}); r != nil {
-				revisions = append(revisions, r)
-			}
-		}
-	} else {
-		revisions = c.RevisionList
+func (c *RevisionCache) List(groupID *int) types.RevisionList {
+	if groupID == nil {
+		return c.RevisionList
 	}
-
-	if opt.GroupID != nil {
-		revisions = revisions.Filter(func(r *types.Revision) bool {
-			return r.GroupID == *opt.GroupID
-		})
-	}
-	return revisions
+	return c.RevisionList.Filter(func(r *types.Revision) bool {
+		return r.GroupID == *groupID
+	})
 }

--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -275,17 +275,17 @@ func (mr *MockStoreMockRecorder) ListFeatureGroup(ctx, entityID interface{}) *go
 }
 
 // ListRevision mocks base method.
-func (m *MockStore) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) types.RevisionList {
+func (m *MockStore) ListRevision(ctx context.Context, groupID *int) types.RevisionList {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRevision", ctx, opt)
+	ret := m.ctrl.Call(m, "ListRevision", ctx, groupID)
 	ret0, _ := ret[0].(types.RevisionList)
 	return ret0
 }
 
 // ListRevision indicates an expected call of ListRevision.
-func (mr *MockStoreMockRecorder) ListRevision(ctx, opt interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) ListRevision(ctx, groupID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRevision", reflect.TypeOf((*MockStore)(nil).ListRevision), ctx, opt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRevision", reflect.TypeOf((*MockStore)(nil).ListRevision), ctx, groupID)
 }
 
 // Refresh mocks base method.
@@ -558,17 +558,17 @@ func (mr *MockReadStoreMockRecorder) ListFeatureGroup(ctx, entityID interface{})
 }
 
 // ListRevision mocks base method.
-func (m *MockReadStore) ListRevision(ctx context.Context, opt metadata.ListRevisionOpt) types.RevisionList {
+func (m *MockReadStore) ListRevision(ctx context.Context, groupID *int) types.RevisionList {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRevision", ctx, opt)
+	ret := m.ctrl.Call(m, "ListRevision", ctx, groupID)
 	ret0, _ := ret[0].(types.RevisionList)
 	return ret0
 }
 
 // ListRevision indicates an expected call of ListRevision.
-func (mr *MockReadStoreMockRecorder) ListRevision(ctx, opt interface{}) *gomock.Call {
+func (mr *MockReadStoreMockRecorder) ListRevision(ctx, groupID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRevision", reflect.TypeOf((*MockReadStore)(nil).ListRevision), ctx, opt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRevision", reflect.TypeOf((*MockReadStore)(nil).ListRevision), ctx, groupID)
 }
 
 // Refresh mocks base method.

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -30,7 +30,7 @@ type ReadStore interface {
 
 	GetRevision(ctx context.Context, id int) (*types.Revision, error)
 	GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error)
-	ListRevision(ctx context.Context, opt ListRevisionOpt) types.RevisionList
+	ListRevision(ctx context.Context, groupID *int) types.RevisionList
 
 	// refresh
 	Refresh() error

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -280,47 +280,27 @@ func TestListRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	defer store.Close()
 
 	_, groupID, _, revisions := prepareRevisions(t, ctx, store)
-	var nilRevisionList types.RevisionList
 	require.NoError(t, store.Refresh())
 
 	testCases := []struct {
 		description string
-		opt         metadata.ListRevisionOpt
+		groupID     *int
 		expected    types.RevisionList
 	}{
 		{
+			description: "list revision, succeed",
+			groupID:     nil,
+			expected:    revisions,
+		},
+		{
 			description: "list revision by groupID, succeed",
-			opt: metadata.ListRevisionOpt{
-				GroupID: &groupID,
-			},
-			expected: revisions,
-		},
-		{
-			description: "list revision by dataTables, succeed",
-			opt: metadata.ListRevisionOpt{
-				DataTables: []string{"device_info_1000", "device_info_2000"},
-			},
-			expected: revisions,
-		},
-		{
-			description: "list revision by invalid dataTables, return empty list",
-			opt: metadata.ListRevisionOpt{
-				DataTables: []string{"device_info_3000"},
-			},
-			expected: nilRevisionList,
-		},
-		{
-			description: "list revision by empty dataTables, return empty list",
-			opt: metadata.ListRevisionOpt{
-				DataTables: []string{},
-				GroupID:    &groupID,
-			},
-			expected: nilRevisionList,
+			groupID:     &groupID,
+			expected:    revisions,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			actual := store.ListRevision(ctx, tc.opt)
+			actual := store.ListRevision(ctx, tc.groupID)
 			for _, item := range actual {
 				ignoreCreateAndModifyTime(item)
 			}

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -56,12 +56,6 @@ type UpdateRevisionOpt struct {
 	NewAnchored *bool
 }
 
-// List
-type ListRevisionOpt struct {
-	GroupID    *int
-	DataTables []string
-}
-
 type ListFeatureOpt struct {
 	EntityID     *int
 	GroupID      *int

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -65,7 +65,7 @@ func buildGroupToFeaturesMap(features types.FeatureList) map[string]types.Featur
 }
 
 func (s *OomStore) buildRevisionRanges(ctx context.Context, groupID int) ([]*metadata.RevisionRange, error) {
-	revisions := s.metadata.ListRevision(ctx, metadata.ListRevisionOpt{GroupID: &groupID})
+	revisions := s.metadata.ListRevision(ctx, &groupID)
 	if len(revisions) == 0 {
 		return nil, nil
 	}

--- a/pkg/oomstore/join_test.go
+++ b/pkg/oomstore/join_test.go
@@ -113,7 +113,7 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureIDs: &tc.opt.FeatureIDs}).Return(tc.features)
 			if tc.entity != nil {
 				for _, featureList := range tc.featureMap {
-					metadataStore.EXPECT().ListRevision(gomock.Any(), metadata.ListRevisionOpt{GroupID: &featureList[0].GroupID}).Return(revisions).AnyTimes()
+					metadataStore.EXPECT().ListRevision(gomock.Any(), &featureList[0].GroupID).Return(revisions).AnyTimes()
 				}
 				offlineStore.EXPECT().Join(gomock.Any(), gomock.Any()).Return(tc.joined, nil)
 			}

--- a/pkg/oomstore/revision.go
+++ b/pkg/oomstore/revision.go
@@ -3,12 +3,11 @@ package oomstore
 import (
 	"context"
 
-	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
 func (s *OomStore) ListRevision(ctx context.Context, groupID *int) types.RevisionList {
-	return s.metadata.ListRevision(ctx, metadata.ListRevisionOpt{GroupID: groupID})
+	return s.metadata.ListRevision(ctx, groupID)
 }
 
 func (s *OomStore) GetRevision(ctx context.Context, id int) (*types.Revision, error) {


### PR DESCRIPTION
This pr simplifies `ListRevisionOpt` since we actually never use `DataTables` to filter revisions.