### PR TITLE
Jinghan/rename offline and online data_table name

### DIFF
--- a/internal/database/metadata/postgres/revision.go
+++ b/internal/database/metadata/postgres/revision.go
@@ -29,7 +29,7 @@ func createRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metad
 	}
 	if opt.DataTable == nil {
 		updateQuery := "UPDATE feature_group_revision SET data_table = $1 WHERE id = $2"
-		dataTable = fmt.Sprintf("data_%d_%d", opt.GroupID, revisionID)
+		dataTable = fmt.Sprintf("offline_%d_%d", opt.GroupID, revisionID)
 		result, err := sqlxCtx.ExecContext(ctx, updateQuery, dataTable, revisionID)
 		if err != nil {
 			return 0, "", err

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -60,7 +60,7 @@ func TestCreateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 			expectedRevision: &types.Revision{
 				ID:          2,
 				Revision:    2000,
-				DataTable:   "data_1_2",
+				DataTable:   "offline_1_2",
 				Anchored:    false,
 				Description: "description",
 				GroupID:     groupID,

--- a/internal/database/offline/test_impl/export.go
+++ b/internal/database/offline/test_impl/export.go
@@ -14,7 +14,7 @@ func TestExport(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
 
-	dataTable := "data_1_1"
+	dataTable := "offline_1_1"
 	features := []*types.Feature{
 		{
 			Name:        "model",

--- a/internal/database/offline/test_impl/import.go
+++ b/internal/database/offline/test_impl/import.go
@@ -20,7 +20,7 @@ func TestImport(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		Name:   "device",
 		Length: 16,
 	}
-	dataTable := "data_1_1"
+	dataTable := "offline_1_1"
 
 	opt := offline.ImportOpt{
 		Entity:        &entity,

--- a/internal/database/offline/test_impl/join.go
+++ b/internal/database/offline/test_impl/join.go
@@ -24,15 +24,15 @@ func TestJoin(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	oneGroupFeatures, oneGroupFeatureMap := prepareFeatures(true)
 	twoGroupFeatures, twoGroupFeatureMap := prepareFeatures(false)
 
-	buildTestDataTable(ctx, t, store, oneGroupFeatures, "data_1_1", csv.NewReader(strings.NewReader(`
+	buildTestDataTable(ctx, t, store, oneGroupFeatures, "offline_1_1", csv.NewReader(strings.NewReader(`
 1234,xiaomi,100
 1235,apple,200
 `)))
-	buildTestDataTable(ctx, t, store, oneGroupFeatures, "data_1_2", csv.NewReader(strings.NewReader(`
+	buildTestDataTable(ctx, t, store, oneGroupFeatures, "offline_1_2", csv.NewReader(strings.NewReader(`
 1234,galaxy,300
 1235,oneplus,240
 `)))
-	buildTestDataTable(ctx, t, store, twoGroupFeatures[2:], "data_2_1", csv.NewReader(strings.NewReader(`
+	buildTestDataTable(ctx, t, store, twoGroupFeatures[2:], "offline_2_1", csv.NewReader(strings.NewReader(`
 1234,true
 1235,false
 `)))
@@ -138,19 +138,19 @@ func prepareRevisionRanges(oneGroup bool) map[string][]*metadata.RevisionRange {
 		{
 			MinRevision: 1,
 			MaxRevision: 15,
-			DataTable:   "data_1_1",
+			DataTable:   "offline_1_1",
 		},
 		{
 			MinRevision: 15,
 			MaxRevision: 25,
-			DataTable:   "data_1_2",
+			DataTable:   "offline_1_2",
 		},
 	}
 	advanced := []*metadata.RevisionRange{
 		{
 			MinRevision: 5,
 			MaxRevision: math.MaxInt64,
-			DataTable:   "data_2_1",
+			DataTable:   "offline_2_1",
 		},
 	}
 	if oneGroup {

--- a/internal/database/online/postgres/get.go
+++ b/internal/database/online/postgres/get.go
@@ -15,7 +15,7 @@ import (
 
 func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error) {
 	featureNames := opt.FeatureList.Names()
-	tableName := getOnlineBatchTableName(opt.RevisionID)
+	tableName := getOnlineTableName(opt.RevisionID)
 	query := fmt.Sprintf(`SELECT %s FROM "%s" WHERE "%s" = $1`, dbutil.Quote(`"`, featureNames...), tableName, opt.Entity.Name)
 
 	record, err := db.QueryRowxContext(ctx, query, opt.EntityKey).SliceScan()
@@ -41,7 +41,7 @@ func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error)
 // response: map[entity_key]map[feature_name]feature_value
 func (db *DB) MultiGet(ctx context.Context, opt online.MultiGetOpt) (map[string]dbutil.RowMap, error) {
 	featureNames := opt.FeatureList.Names()
-	tableName := getOnlineBatchTableName(opt.RevisionID)
+	tableName := getOnlineTableName(opt.RevisionID)
 	query := fmt.Sprintf(`SELECT "%s", %s FROM "%s" WHERE "%s" in (?);`, opt.Entity.Name, dbutil.Quote(`"`, featureNames...), tableName, opt.Entity.Name)
 	sql, args, err := sqlx.In(query, opt.EntityKeys)
 	if err != nil {

--- a/internal/database/online/postgres/import.go
+++ b/internal/database/online/postgres/import.go
@@ -49,7 +49,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 		}
 
 		// rename the tmp table to final table
-		finalTableName := getOnlineBatchTableName(opt.Revision.ID)
+		finalTableName := getOnlineTableName(opt.Revision.ID)
 		rename := fmt.Sprintf(`ALTER TABLE "%s" RENAME TO "%s"`, tmpTableName, finalTableName)
 		_, err = tx.ExecContext(ctx, rename)
 		return err
@@ -57,6 +57,6 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 	return err
 }
 
-func getOnlineBatchTableName(revisionID int) string {
-	return fmt.Sprintf("batch_%d", revisionID)
+func getOnlineTableName(revisionID int) string {
+	return fmt.Sprintf("online_%d", revisionID)
 }

--- a/internal/database/online/postgres/purge.go
+++ b/internal/database/online/postgres/purge.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (db *DB) Purge(ctx context.Context, revisionID int) error {
-	query := fmt.Sprintf(`DROP TABLE IF EXISTS "%s";`, getOnlineBatchTableName(revisionID))
+	query := fmt.Sprintf(`DROP TABLE IF EXISTS "%s";`, getOnlineTableName(revisionID))
 	if _, err := db.ExecContext(ctx, query); err != nil {
 		return err
 	}

--- a/pkg/oomstore/import_test.go
+++ b/pkg/oomstore/import_test.go
@@ -234,7 +234,7 @@ device,model,price
 				Revision:    0,
 				GroupID:     tc.opt.GroupID,
 				Description: tc.opt.Description,
-			}).Return(tc.revisionID, "data_1_1", nil).AnyTimes()
+			}).Return(tc.revisionID, "offline_1_1", nil).AnyTimes()
 
 			offlineStore.EXPECT().Import(ctx, gomock.Any()).Return(int64(1000), nil).AnyTimes()
 


### PR DESCRIPTION
This PR does:
- rename offline data_table name to `offline_<group_id>_<revision_id>`
- rename online postgres data_table name to `online_<revision_id>`
