### PR TITLE
Jinghan/refactor types.CreateGroupOpt

### DIFF
--- a/featctl/cmd/register_batch_feature.go
+++ b/featctl/cmd/register_batch_feature.go
@@ -8,13 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type registerBatchFeatureOption struct {
-	types.CreateFeatureOpt
-	groupName string
-}
-
-var registerBatchFeatureOpt registerBatchFeatureOption
-
+var registerBatchFeatureOpt types.CreateFeatureOpt
 var registerBatchFeatureCmd = &cobra.Command{
 	Use:     "batch-feature",
 	Short:   "register a new batch feature",
@@ -28,13 +22,7 @@ var registerBatchFeatureCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		group, err := oomStore.GetGroupByName(ctx, registerBatchFeatureOpt.groupName)
-		if err != nil {
-			log.Fatalf("failed to get feature group name=%s: %v", registerBatchFeatureOpt.groupName, err)
-		}
-		registerBatchFeatureOpt.GroupID = group.ID
-
-		if _, err := oomStore.CreateBatchFeature(ctx, registerBatchFeatureOpt.CreateFeatureOpt); err != nil {
+		if _, err := oomStore.CreateBatchFeature(ctx, registerBatchFeatureOpt); err != nil {
 			log.Fatalf("failed registering new feature: %v\n", err)
 		}
 	},
@@ -45,7 +33,7 @@ func init() {
 
 	flags := registerBatchFeatureCmd.Flags()
 
-	flags.StringVarP(&registerBatchFeatureOpt.groupName, "group", "g", "", "feature group")
+	flags.StringVarP(&registerBatchFeatureOpt.GroupName, "group", "g", "", "feature group")
 	_ = registerBatchFeatureCmd.MarkFlagRequired("group")
 
 	flags.StringVarP(&registerBatchFeatureOpt.DBValueType, "db-value-type", "", "", "feature value type in database")

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -38,13 +38,11 @@ func TestCreateFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "phone",
-			GroupID:     groupID,
-			DBValueType: "varchar(16)",
-			Description: "description",
-		},
-		ValueType: "string",
+		FeatureName: "phone",
+		GroupID:     groupID,
+		DBValueType: "varchar(16)",
+		Description: "description",
+		ValueType:   "string",
 	}
 
 	_, err := store.CreateFeature(ctx, opt)
@@ -57,11 +55,9 @@ func TestCreateFeatureWithSameName(t *testing.T, prepareStore PrepareStoreRuntim
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "phone",
-			GroupID:     groupID,
-			DBValueType: "varchar(16)",
-		},
+		FeatureName: "phone",
+		GroupID:     groupID,
+		DBValueType: "varchar(16)",
 	}
 
 	_, err := store.CreateFeature(ctx, opt)
@@ -77,12 +73,10 @@ func TestCreateFeatureWithSQLKeywrod(t *testing.T, prepareStore PrepareStoreRunt
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "user",
-			GroupID:     groupID,
-			DBValueType: "int",
-			Description: "order",
-		},
+		FeatureName: "user",
+		GroupID:     groupID,
+		DBValueType: "int",
+		Description: "order",
 	}
 
 	_, err := store.CreateFeature(ctx, opt)
@@ -95,11 +89,9 @@ func TestCreateFeatureWithInvalidDataType(t *testing.T, prepareStore PrepareStor
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	_, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "model",
-			GroupID:     groupID,
-			DBValueType: "invalid_type",
-		},
+		FeatureName: "model",
+		GroupID:     groupID,
+		DBValueType: "invalid_type",
 	})
 	require.Error(t, err)
 }
@@ -110,13 +102,11 @@ func TestGetFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	id, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "phone",
-			GroupID:     groupID,
-			DBValueType: "varchar(16)",
-			Description: "description",
-		},
-		ValueType: "string",
+		FeatureName: "phone",
+		GroupID:     groupID,
+		DBValueType: "varchar(16)",
+		Description: "description",
+		ValueType:   "string",
 	})
 	require.NoError(t, err)
 
@@ -142,13 +132,11 @@ func TestListFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.Equal(t, 0, features.Len())
 
 	featureID, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "phone",
-			GroupID:     groupID,
-			DBValueType: "varchar(16)",
-			Description: "description",
-		},
-		ValueType: "string",
+		FeatureName: "phone",
+		GroupID:     groupID,
+		DBValueType: "varchar(16)",
+		Description: "description",
+		ValueType:   "string",
 	})
 	require.NoError(t, err)
 
@@ -186,13 +174,11 @@ func TestUpdateFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
 
 	opt := metadata.CreateFeatureOpt{
-		CreateFeatureOpt: types.CreateFeatureOpt{
-			FeatureName: "phone",
-			GroupID:     groupID,
-			DBValueType: "varchar(16)",
-			Description: "description",
-		},
-		ValueType: "string",
+		FeatureName: "phone",
+		GroupID:     groupID,
+		DBValueType: "varchar(16)",
+		Description: "description",
+		ValueType:   "string",
 	}
 	id, err := store.CreateFeature(ctx, opt)
 	require.NoError(t, err)

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -14,8 +14,11 @@ type CreateEntityOpt struct {
 }
 
 type CreateFeatureOpt struct {
-	types.CreateFeatureOpt
-	ValueType string
+	FeatureName string
+	GroupID     int
+	DBValueType string
+	Description string
+	ValueType   string
 }
 
 type CreateGroupOpt struct {

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -49,7 +49,7 @@ func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt
 }
 
 func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) (int, error) {
-	group, err := s.metadata.GetGroup(ctx, opt.GroupID)
+	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err
 	}
@@ -62,7 +62,10 @@ func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatu
 		return 0, err
 	}
 	return s.metadata.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		CreateFeatureOpt: opt,
-		ValueType:        valueType,
+		FeatureName: opt.FeatureName,
+		GroupID:     group.ID,
+		DBValueType: opt.DBValueType,
+		ValueType:   valueType,
+		Description: opt.Description,
 	})
 }

--- a/pkg/oomstore/feature_test.go
+++ b/pkg/oomstore/feature_test.go
@@ -18,6 +18,8 @@ import (
 func TestCreateBatchFeature(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	ctx := context.Background()
+
 	offlineStore := mock_offline.NewMockStore(ctrl)
 	metadataStore := mock_metadata.NewMockStore(ctrl)
 	store := oomstore.TEST__New(nil, offlineStore, metadataStore)
@@ -33,11 +35,12 @@ func TestCreateBatchFeature(t *testing.T) {
 			description: "create batch feature, succeed",
 			opt: types.CreateFeatureOpt{
 				FeatureName: "model",
-				GroupID:     1,
+				GroupName:   "device_info",
 				DBValueType: "VARCHAR(32)",
 			},
 			valueType: types.STRING,
 			group: types.Group{
+				ID:       1,
 				Name:     "device_info",
 				Category: types.BatchFeatureCategory,
 			},
@@ -47,11 +50,12 @@ func TestCreateBatchFeature(t *testing.T) {
 			description: "create stream feature, fail",
 			opt: types.CreateFeatureOpt{
 				FeatureName: "model",
-				GroupID:     1,
+				GroupName:   "device_info",
 				DBValueType: "BIGINT",
 			},
 			valueType: types.INT64,
 			group: types.Group{
+				ID:       1,
 				Name:     "device_info",
 				Category: types.StreamFeatureCategory,
 			},
@@ -61,19 +65,20 @@ func TestCreateBatchFeature(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			metadataStore.EXPECT().
-				GetGroup(gomock.Any(), tc.opt.GroupID).
-				Return(&tc.group, nil)
+			metadataStore.EXPECT().GetGroupByName(ctx, tc.opt.GroupName).Return(&tc.group, nil)
 
 			if tc.group.Category == types.BatchFeatureCategory {
 				metadataOpt := metadata.CreateFeatureOpt{
-					CreateFeatureOpt: tc.opt,
-					ValueType:        tc.valueType,
+					FeatureName: tc.opt.FeatureName,
+					GroupID:     tc.group.ID,
+					DBValueType: tc.opt.DBValueType,
+					ValueType:   tc.valueType,
+					Description: tc.opt.Description,
 				}
 				offlineStore.EXPECT().TypeTag(tc.opt.DBValueType).Return(tc.valueType, nil)
-				metadataStore.EXPECT().CreateFeature(gomock.Any(), metadataOpt).Return(0, nil)
+				metadataStore.EXPECT().CreateFeature(ctx, metadataOpt).Return(0, nil)
 			}
-			_, err := store.CreateBatchFeature(context.Background(), tc.opt)
+			_, err := store.CreateBatchFeature(ctx, tc.opt)
 			if tc.expectError {
 				assert.Error(t, err, fmt.Errorf("expected batch feature group, got %s feature group", tc.group.Category))
 			} else {

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -6,7 +6,7 @@ import (
 
 type CreateFeatureOpt struct {
 	FeatureName string
-	GroupID     int
+	GroupName   string
 	DBValueType string
 	Description string
 }


### PR DESCRIPTION
This PR refactors `types.CreateGroupOpt`:
- changes field `GroupID` to `GroupName`
- use `GroupID` in database layer, while `GroupName` in oomstore and featctl