### PR TITLE
Jinghan/use FeatureNames in JoinOpt and OnlineMultiGetOpt

### DIFF
--- a/featctl/cmd/join_helper.go
+++ b/featctl/cmd/join_helper.go
@@ -25,16 +25,9 @@ func join(ctx context.Context, store *oomstore.OomStore, opt JoinOpt, output str
 		return err
 	}
 
-	features, err := store.ListFeature(ctx, types.ListFeatureOpt{
-		FeatureNames: &opt.FeatureNames,
-	})
-	if err != nil {
-		return nil
-	}
-
 	joinResult, err := store.Join(ctx, types.JoinOpt{
-		FeatureIDs: features.IDs(),
-		EntityRows: entityRows,
+		FeatureNames: opt.FeatureNames,
+		EntityRows:   entityRows,
 	})
 	if err != nil {
 		return err

--- a/pkg/oomstore/export_test.go
+++ b/pkg/oomstore/export_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func TestExportFeatureValues(t *testing.T) {
+func TestExport(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	ctx := context.Background()

--- a/pkg/oomstore/import_test.go
+++ b/pkg/oomstore/import_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestImportBatchFeatureWithDependencyError(t *testing.T) {
+func TestImportWithDependencyError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -120,7 +120,7 @@ device,model,price
 	}
 }
 
-func TestImportBatchFeatures(t *testing.T) {
+func TestImport(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -14,7 +14,9 @@ import (
 // Join gets point-in-time feature values for each entity row;
 // currently, this API only supports batch features.
 func (s *OomStore) Join(ctx context.Context, opt types.JoinOpt) (*types.JoinResult, error) {
-	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{FeatureIDs: &opt.FeatureIDs})
+	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
+		FeatureNames: &opt.FeatureNames,
+	})
 
 	features = features.Filter(func(f *types.Feature) bool {
 		return f.Group.Category == types.BatchFeatureCategory

--- a/pkg/oomstore/join_test.go
+++ b/pkg/oomstore/join_test.go
@@ -57,8 +57,8 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "no valid features, return nil",
 			opt: types.JoinOpt{
-				FeatureIDs: streamFeatures.IDs(),
-				EntityRows: entityRows,
+				FeatureNames: streamFeatures.Names(),
+				EntityRows:   entityRows,
 			},
 			features:      streamFeatures,
 			expectedError: nil,
@@ -67,8 +67,8 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "inconsistent features, return nil",
 			opt: types.JoinOpt{
-				FeatureIDs: inconsistentFeatures.IDs(),
-				EntityRows: entityRows,
+				FeatureNames: inconsistentFeatures.Names(),
+				EntityRows:   entityRows,
 			},
 			features:      inconsistentFeatures,
 			expectedError: fmt.Errorf("inconsistent entity type: %v", map[string]string{"device": "price", "user": "age"}),
@@ -77,8 +77,8 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "nil joined, return nil",
 			opt: types.JoinOpt{
-				FeatureIDs: consistentFeatures.IDs(),
-				EntityRows: entityRows,
+				FeatureNames: consistentFeatures.Names(),
+				EntityRows:   entityRows,
 			},
 			entity:   &entity,
 			features: consistentFeatures,
@@ -93,8 +93,8 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 		{
 			description: "consistent entity type, succeed",
 			opt: types.JoinOpt{
-				FeatureIDs: consistentFeatures.IDs(),
-				EntityRows: entityRows,
+				FeatureNames: consistentFeatures.Names(),
+				EntityRows:   entityRows,
 			},
 			entity:   &entity,
 			features: consistentFeatures,
@@ -110,7 +110,7 @@ func TestGetHistoricalFeatureValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureIDs: &tc.opt.FeatureIDs}).Return(tc.features)
+			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureNames: &tc.opt.FeatureNames}).Return(tc.features)
 			if tc.entity != nil {
 				for _, featureList := range tc.featureMap {
 					metadataStore.EXPECT().ListRevision(gomock.Any(), &featureList[0].GroupID).Return(revisions).AnyTimes()

--- a/pkg/oomstore/join_test.go
+++ b/pkg/oomstore/join_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetHistoricalFeatureValues(t *testing.T) {
+func TestJoin(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	offlineStore := mock_offline.NewMockStore(ctrl)

--- a/pkg/oomstore/online_query.go
+++ b/pkg/oomstore/online_query.go
@@ -11,7 +11,9 @@ import (
 )
 
 func (s *OomStore) OnlineGet(ctx context.Context, opt types.OnlineGetOpt) (*types.FeatureValues, error) {
-	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{FeatureNames: &opt.FeatureNames})
+	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
+		FeatureNames: &opt.FeatureNames,
+	})
 	entity, err := s.getSharedEntity(features)
 	if err != nil {
 		return nil, err
@@ -54,7 +56,9 @@ func (s *OomStore) OnlineGet(ctx context.Context, opt types.OnlineGetOpt) (*type
 }
 
 func (s *OomStore) OnlineMultiGet(ctx context.Context, opt types.OnlineMultiGetOpt) (types.FeatureDataSet, error) {
-	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{FeatureIDs: &opt.FeatureIDs})
+	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
+		FeatureNames: &opt.FeatureNames,
+	})
 
 	features = features.Filter(func(f *types.Feature) bool {
 		return f.OnlineRevisionID() != nil

--- a/pkg/oomstore/online_query_test.go
+++ b/pkg/oomstore/online_query_test.go
@@ -127,8 +127,8 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 		{
 			description: "no available features, return nil",
 			opt: types.OnlineMultiGetOpt{
-				FeatureIDs: unavailableFeatures.IDs(),
-				EntityKeys: []string{"1234", "1235"},
+				FeatureNames: unavailableFeatures.Names(),
+				EntityKeys:   []string{"1234", "1235"},
 			},
 			features:      unavailableFeatures,
 			expectedError: nil,
@@ -137,8 +137,8 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 		{
 			description: "inconsistent entity type, fail",
 			opt: types.OnlineMultiGetOpt{
-				FeatureIDs: inconsistentFeatures.IDs(),
-				EntityKeys: []string{"1234", "1235"},
+				FeatureNames: inconsistentFeatures.Names(),
+				EntityKeys:   []string{"1234", "1235"},
 			},
 			features:      inconsistentFeatures,
 			expectedError: fmt.Errorf("expected 1 entity, got 2 entities"),
@@ -147,8 +147,8 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 		{
 			description: "consistent entity type, succeed",
 			opt: types.OnlineMultiGetOpt{
-				FeatureIDs: consistentFeatures.IDs(),
-				EntityKeys: []string{"1234", "1235"},
+				FeatureNames: consistentFeatures.Names(),
+				EntityKeys:   []string{"1234", "1235"},
 			},
 			features:      consistentFeatures,
 			entityName:    &entityName,
@@ -180,7 +180,7 @@ func TestMultiGetOnlineFeatureValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureIDs: &tc.opt.FeatureIDs}).Return(tc.features)
+			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureNames: &tc.opt.FeatureNames}).Return(tc.features)
 			if tc.entityName != nil {
 				onlineStore.EXPECT().MultiGet(gomock.Any(), gomock.Any()).Return(map[string]dbutil.RowMap{
 					"1234": {

--- a/pkg/oomstore/online_query_test.go
+++ b/pkg/oomstore/online_query_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetOnlineFeatureValues(t *testing.T) {
+func TestOnlineGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	onlineStore := mock_online.NewMockStore(ctrl)
@@ -103,7 +103,7 @@ func TestGetOnlineFeatureValues(t *testing.T) {
 	}
 }
 
-func TestMultiGetOnlineFeatureValues(t *testing.T) {
+func TestOnlineMultiGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	onlineStore := mock_online.NewMockStore(ctrl)

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -58,8 +58,8 @@ type OnlineGetOpt struct {
 }
 
 type OnlineMultiGetOpt struct {
-	FeatureIDs []int
-	EntityKeys []string
+	FeatureNames []string
+	EntityKeys   []string
 }
 
 type JoinOpt struct {

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -63,8 +63,8 @@ type OnlineMultiGetOpt struct {
 }
 
 type JoinOpt struct {
-	FeatureIDs []int
-	EntityRows <-chan EntityRow
+	FeatureNames []string
+	EntityRows   <-chan EntityRow
 }
 
 type UpdateEntityOpt struct {


### PR DESCRIPTION
This PR does:
- refactor `types.OnlineMultiGetOpt`: replace field `FeatureIDs` by `FeatureNames`
- refactor `types.JoinOpt`: replace field `FeatureIDs` by `FeatureNames`
- shorten oomstore unit test name