### PR TITLE
Jinghan/change ImportOpt.GroupID to ImportOpt.GroupName

### DIFF
--- a/featctl/cmd/import.go
+++ b/featctl/cmd/import.go
@@ -12,8 +12,7 @@ import (
 
 type importOption struct {
 	types.ImportOpt
-	FilePath  string
-	groupName string
+	FilePath string
 }
 
 var importOpt importOption
@@ -30,12 +29,6 @@ var importCmd = &cobra.Command{
 		ctx := context.Background()
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
-
-		if group, err := oomStore.GetGroupByName(ctx, importOpt.groupName); err != nil {
-			log.Fatalf("failed to get feature group name=%s: %v", importOpt.groupName, err)
-		} else {
-			importOpt.GroupID = group.ID
-		}
 
 		file, err := os.Open(importOpt.FilePath)
 		if err != nil {
@@ -60,7 +53,7 @@ func init() {
 
 	flags := importCmd.Flags()
 
-	flags.StringVarP(&importOpt.groupName, "group", "g", "", "feature group")
+	flags.StringVarP(&importOpt.GroupName, "group", "g", "", "feature group")
 	_ = importCmd.MarkFlagRequired("group")
 
 	flags.StringVar(&importOpt.Description, "description", "", "revision description")

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -42,20 +42,21 @@ func stringSliceEqual(a, b []string) bool {
 }
 
 func (s *OomStore) Import(ctx context.Context, opt types.ImportOpt) (int, error) {
-	// get columns of the group
-	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &opt.GroupID})
-	if features == nil {
-		return 0, fmt.Errorf("no features under group id: '%d'", opt.GroupID)
-	}
-
-	// get entity info
-	group, err := s.GetGroup(ctx, opt.GroupID)
+	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err
 	}
+
+	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
+		GroupID: &group.ID,
+	})
+	if features == nil {
+		return 0, fmt.Errorf("no features under group: %s", opt.GroupName)
+	}
+
 	entity := group.Entity
 	if entity == nil {
-		return 0, fmt.Errorf("no entity found by group id: '%d'", opt.GroupID)
+		return 0, fmt.Errorf("no entity found by group: %s", opt.GroupName)
 	}
 
 	// make sure csv data source has all defined columns

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -41,7 +41,7 @@ type ExportFeatureValuesOpt struct {
 }
 
 type ImportOpt struct {
-	GroupID     int
+	GroupName   string
 	Description string
 	DataSource  CsvDataSource
 	Revision    *int64


### PR DESCRIPTION
This PR refactors `types.ImportOpt`: changes field `GroupID` to `GroupName`.