### PR TITLE
doc: more detailed --help

### DIFF
--- a/featctl/cmd/describe_entity.go
+++ b/featctl/cmd/describe_entity.go
@@ -9,7 +9,7 @@ import (
 )
 
 var describeEntityCmd = &cobra.Command{
-	Use:   "entity",
+	Use:   "entity <entity_name>",
 	Short: "show details of a specific entity",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/featctl/cmd/describe_feature.go
+++ b/featctl/cmd/describe_feature.go
@@ -9,7 +9,7 @@ import (
 )
 
 var describeFeatureCmd = &cobra.Command{
-	Use:   "feature",
+	Use:   "feature <feature_name>",
 	Short: "show details of a specific feature",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/featctl/cmd/describe_group.go
+++ b/featctl/cmd/describe_group.go
@@ -9,7 +9,7 @@ import (
 )
 
 var describeGroupCmd = &cobra.Command{
-	Use:   "group",
+	Use:   "group <group_name>",
 	Short: "show details of a specific group",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/featctl/cmd/list_group.go
+++ b/featctl/cmd/list_group.go
@@ -23,9 +23,6 @@ var listGroupOpt listGroupOption
 var listGroupCmd = &cobra.Command{
 	Use:   "group",
 	Short: "list feature groups",
-	Example: `1. featctl list group
-2. featctl list group --entity device
-`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if !cmd.Flags().Changed("entity") {
 			listGroupOpt.entityName = nil

--- a/featctl/cmd/register_batch_feature.go
+++ b/featctl/cmd/register_batch_feature.go
@@ -10,10 +10,9 @@ import (
 
 var registerBatchFeatureOpt types.CreateFeatureOpt
 var registerBatchFeatureCmd = &cobra.Command{
-	Use:     "batch-feature",
-	Short:   "register a new batch feature",
-	Example: `featctl register feature model --group device --value-type "varchar(30)" --description 'phone model'`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "batch-feature <feature_name>",
+	Short: "register a new batch feature",
+	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		registerBatchFeatureOpt.FeatureName = args[0]
 	},

--- a/featctl/cmd/register_entity.go
+++ b/featctl/cmd/register_entity.go
@@ -11,7 +11,7 @@ import (
 var registerEntityOpt types.CreateEntityOpt
 
 var registerEntityCmd = &cobra.Command{
-	Use:   "entity",
+	Use:   "entity <entity_name>",
 	Short: "register a new entity",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/featctl/cmd/register_group.go
+++ b/featctl/cmd/register_group.go
@@ -10,7 +10,7 @@ import (
 
 var registerGroupOpt types.CreateGroupOpt
 var registerGroupCmd = &cobra.Command{
-	Use:   "group",
+	Use:   "group <group_name>",
 	Short: "register a new feature group",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {

--- a/featctl/cmd/update_entity.go
+++ b/featctl/cmd/update_entity.go
@@ -11,8 +11,8 @@ import (
 var updateEntityOpt types.UpdateEntityOpt
 
 var updateEntityCmd = &cobra.Command{
-	Use:   "entity",
-	Short: "update a specified entity",
+	Use:   "entity <entity_name>",
+	Short: "update a particular entity",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		updateEntityOpt.EntityName = args[0]

--- a/featctl/cmd/update_feature.go
+++ b/featctl/cmd/update_feature.go
@@ -11,8 +11,8 @@ import (
 var updateFeatureOpt types.UpdateFeatureOpt
 
 var updateFeatureCmd = &cobra.Command{
-	Use:   "feature",
-	Short: "update a specified feature",
+	Use:   "feature <feature_name>",
+	Short: "update a particular feature",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		updateFeatureOpt.FeatureName = args[0]

--- a/featctl/cmd/update_group.go
+++ b/featctl/cmd/update_group.go
@@ -11,8 +11,8 @@ import (
 var updateGroupOpt types.UpdateGroupOpt
 
 var updateGroupCmd = &cobra.Command{
-	Use:   "group",
-	Short: "update a specified group",
+	Use:   "group <group_name>",
+	Short: "update a particular group",
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		updateGroupOpt.GroupName = args[0]


### PR DESCRIPTION
Learn from https://github.com/spf13/cobra/issues/571#issuecomment-707231598.

Note the difference in "Usage".

before:

```
$ featctl describe entity --help
show details of a specific entity

Usage:
  featctl describe entity [flags]

Flags:
  -h, --help   help for entity

Global Flags:
      --config string   config file (default "/Users/chenyisheng/.config/featctl/config.yaml")
```

after:

```
$ featctl describe entity --help
show details of a specific entity

Usage:
  featctl describe entity <entity_name> [flags]

Flags:
  -h, --help   help for entity

Global Flags:
      --config string   config file (default "/Users/chenyisheng/.config/featctl/config.yaml")
```

close #530 