### PR TITLE
fix(database): remove unnecessary dropTemporaryTables

### DIFF
--- a/internal/database/offline/postgres/join.go
+++ b/internal/database/offline/postgres/join.go
@@ -125,9 +125,6 @@ func (db *DB) readJoinedTable(ctx context.Context, entityRowsTableName string, t
 	if err != nil {
 		return nil, err
 	}
-	if err := db.dropTemporaryTables(ctx, tableNames); err != nil {
-		return nil, err
-	}
 	header, err := rows.Columns()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`dropTemporaryTables` should be executed after all rows have been read.