### PR TITLE
feat(errdefs): Add error mechanism for oomstore

### DIFF
--- a/pkg/errdefs/defs.go
+++ b/pkg/errdefs/defs.go
@@ -1,0 +1,5 @@
+package errdefs
+
+type ErrNotFound interface {
+	NotFound()
+}

--- a/pkg/errdefs/helper.go
+++ b/pkg/errdefs/helper.go
@@ -1,0 +1,16 @@
+package errdefs
+
+type errNotFound struct{ error }
+
+func (errNotFound) NotFound() {}
+
+func (e errNotFound) Unwrap() error {
+	return e.error
+}
+
+func NotFound(err error) error {
+	if err == nil || IsNotFound(err) {
+		return err
+	}
+	return errNotFound{err}
+}

--- a/pkg/errdefs/helper_test.go
+++ b/pkg/errdefs/helper_test.go
@@ -1,0 +1,26 @@
+package errdefs_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oom-ai/oomstore/pkg/errdefs"
+)
+
+var errTest = errors.New("this is a test")
+
+func TestErrNotFound(t *testing.T) {
+	if errdefs.IsNotFound(errTest) {
+		t.Fatalf("did not expect not found error, got %T", errTest)
+	}
+
+	e := errdefs.NotFound(errTest)
+
+	if !errdefs.IsNotFound(e) {
+		t.Fatalf("expected not found error, got: %T", e)
+	}
+
+	if !errors.Is(e, errTest) {
+		t.Fatalf("expected not found error to match errTest")
+	}
+}

--- a/pkg/errdefs/is.go
+++ b/pkg/errdefs/is.go
@@ -1,0 +1,7 @@
+package errdefs
+
+import "errors"
+
+func IsNotFound(err error) bool {
+	return errors.As(err, &errNotFound{})
+}


### PR DESCRIPTION
This PR adds a mechanism for handling errors, which is responsible for defining the type of error in the oomstore and providing a way to check the error type.

This is an example for apply：

```go
func (f *Informer) GetEntityByName(ctx context.Context, name string) (*types.Entity, error) {
	if entity := f.Cache().Entities.Find(func(e *types.Entity) bool {
		return e.Name == name
	}); entity == nil {
		return nil, errdefs.NotFound(fmt.Errorf("feature entity '%s' not found", name))
	} else {
		return entity.Copy(), nil
	}
}

---

func (s *OomStore) applyEntity(ctx context.Context, txStore metadata.WriteStore, newEntity apply.Entity) (int, error) {
	entityExist := true

	entity, err := s.metadata.GetEntityByName(ctx, newEntity.Name)
	if err != nil {
                 if !errdefs.IsNotFound(err) {
                    return 0, err
                 }
		entityExist = false
	}

```
