### PR TITLE
feat(oomd): adding a configuration system

### DIFF
--- a/oomd/main.go
+++ b/oomd/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	Execute()
+}

--- a/oomd/root.go
+++ b/oomd/root.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v2"
+
+	"github.com/oom-ai/oomstore/oomd/codegen"
+	"github.com/oom-ai/oomstore/pkg/oomstore"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+	"github.com/oom-ai/oomstore/version"
+)
+
+var cfgFile string
+var defaultCfgFile = filepath.Join(xdg.Home, ".config", "oomd", "config.yaml")
+
+var oomStoreCfg types.OomStoreConfig
+var port int
+
+// rootCmd represents the base command when called without and subcommands
+var rootCmd = &cobra.Command{
+	Use:     "oomd",
+	Short:   "a cli tool that lets you start oom feature store grpc backend.",
+	Version: version.String(),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		oomStore, err := oomstore.Open(ctx, oomStoreCfg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer oomStore.Close()
+
+		lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+		if err != nil {
+			log.Fatalf("failed to listen: %v", err)
+		}
+		grpcServer := grpc.NewServer()
+		codegen.RegisterOomDServer(grpcServer, &server{oomstore: oomStore})
+		if err := grpcServer.Serve(lis); err != nil {
+			panic(err)
+		}
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	rootCmd.SetHelpCommand(&cobra.Command{
+		Use:    "no-help",
+		Hidden: true,
+	})
+
+	pFlags := rootCmd.Flags()
+	pFlags.StringVar(&cfgFile, "config", defaultCfgFile, "config file")
+	pFlags.IntVarP(&port, "port", "p", 50051, "The server port")
+
+	rootCmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
+}
+
+// initConfig reads in config file
+func initConfig() {
+	if envCfgFile := os.Getenv("OOMD_CONFIG"); envCfgFile != "" {
+		cfgFile = envCfgFile
+	}
+	cfgContent, err := ioutil.ReadFile(cfgFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed reading config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := yaml.Unmarshal(cfgContent, &oomStoreCfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed loading config : %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/oomd/root.go
+++ b/oomd/root.go
@@ -29,7 +29,7 @@ var port int
 // rootCmd represents the base command when called without and subcommands
 var rootCmd = &cobra.Command{
 	Use:     "oomd",
-	Short:   "a cli tool that lets you start oom feature store grpc backend.",
+	Short:   "oomstore daemon",
 	Version: version.String(),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()

--- a/oomd/server.go
+++ b/oomd/server.go
@@ -3,19 +3,17 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"log"
-	"net"
+
+	code "google.golang.org/genproto/googleapis/rpc/code"
+	status "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/oom-ai/oomstore/oomd/codegen"
 	"github.com/oom-ai/oomstore/pkg/oomstore"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	code "google.golang.org/genproto/googleapis/rpc/code"
-	status "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type server struct {
@@ -222,59 +220,5 @@ func buildStatus(code code.Code, message string) *status.Status {
 	return &status.Status{
 		Code:    int32(code),
 		Message: message,
-	}
-}
-
-// The methods below serves the temporary testing purpose
-// We should add more formal tests soon
-func newServer() *server {
-	store, err := oomstore.Open(context.Background(), buildOomStoreConfig())
-	if err != nil {
-		log.Fatal(err)
-	}
-	return &server{oomstore: store}
-}
-
-func buildOomStoreConfig() types.OomStoreConfig {
-	return types.OomStoreConfig{
-		MetadataStore: types.MetadataStoreConfig{
-			Backend:  types.POSTGRES,
-			Postgres: getPostgresOpt(),
-		},
-		OnlineStore: types.OnlineStoreConfig{
-			Backend:  types.POSTGRES,
-			Postgres: getPostgresOpt(),
-		},
-		OfflineStore: types.OfflineStoreConfig{
-			Backend:  types.POSTGRES,
-			Postgres: getPostgresOpt(),
-		},
-	}
-}
-
-func getPostgresOpt() *types.PostgresOpt {
-	return &types.PostgresOpt{
-		Host:     "127.0.0.1",
-		Port:     "5432",
-		User:     "postgres",
-		Password: "postgres",
-		Database: "oomstore",
-	}
-}
-
-var (
-	port = flag.Int("port", 50051, "The server port")
-)
-
-func main() {
-	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-	grpcServer := grpc.NewServer()
-	codegen.RegisterOomDServer(grpcServer, newServer())
-	if err := grpcServer.Serve(lis); err != nil {
-		panic(err)
 	}
 }


### PR DESCRIPTION
This PR adds a configuration system to oomd so that oomd can initialise the oomstore using configuration files and environment variables like featctl.

It also makes it easier for python to start oomd

relate #582 