### PR TITLE
Jinghan/refresh informer for all non performance-critical oomstore APIs

### DIFF
--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -15,6 +15,9 @@ import (
 )
 
 func (s *OomStore) Apply(ctx context.Context, opt apply.ApplyOpt) error {
+	if err := s.metadata.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	stage, err := buildApplyStage(ctx, opt)
 	if err != nil {
 		return err

--- a/pkg/oomstore/entity.go
+++ b/pkg/oomstore/entity.go
@@ -2,6 +2,7 @@ package oomstore
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -9,21 +10,31 @@ import (
 
 // Get metadata of an entity by ID.
 func (s *OomStore) GetEntity(ctx context.Context, id int) (*types.Entity, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetEntity(ctx, id)
 }
 
 // Get metadata of an entity by name.
 func (s *OomStore) GetEntityByName(ctx context.Context, name string) (*types.Entity, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetEntityByName(ctx, name)
 }
 
 // List metadata of all entities.
 func (s *OomStore) ListEntity(ctx context.Context) types.EntityList {
+	_ = s.metadata.Refresh()
 	return s.metadata.ListEntity(ctx)
 }
 
 // Create metadata for an entity.
 func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) (int, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.CreateEntity(ctx, metadata.CreateEntityOpt{
 		CreateEntityOpt: opt,
 	})
@@ -31,6 +42,9 @@ func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) 
 
 // Update metadata for an entity.
 func (s *OomStore) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error {
+	if err := s.metadata.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	entity, err := s.metadata.GetEntityByName(ctx, opt.EntityName)
 	if err != nil {
 		return err

--- a/pkg/oomstore/export.go
+++ b/pkg/oomstore/export.go
@@ -10,6 +10,9 @@ import (
 
 // Export feature values of a particular revision.
 func (s *OomStore) Export(ctx context.Context, opt types.ExportOpt) ([]string, <-chan *types.ExportRecord, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	revision, err := s.GetRevision(ctx, opt.RevisionID)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/oomstore/export_test.go
+++ b/pkg/oomstore/export_test.go
@@ -71,6 +71,7 @@ func TestExport(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			revision := types.Revision{
 				ID:        1,
 				GroupID:   1,

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -10,16 +10,25 @@ import (
 
 // Get metadata of a feature by ID.
 func (s *OomStore) GetFeature(ctx context.Context, id int) (*types.Feature, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetFeature(ctx, id)
 }
 
 // Get metadata of a feature by name.
 func (s *OomStore) GetFeatureByName(ctx context.Context, name string) (*types.Feature, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetFeatureByName(ctx, name)
 }
 
 // List metadata of features meeting particular criteria.
 func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	metadataOpt := metadata.ListFeatureOpt{
 		FeatureNames: opt.FeatureNames,
 	}
@@ -42,6 +51,9 @@ func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (t
 
 // Update metadata of a feature.
 func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error {
+	if err := s.metadata.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	feature, err := s.metadata.GetFeatureByName(ctx, opt.FeatureName)
 	if err != nil {
 		return err
@@ -54,6 +66,9 @@ func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt
 
 // Create metadata of a batch feature.
 func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) (int, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err

--- a/pkg/oomstore/feature_test.go
+++ b/pkg/oomstore/feature_test.go
@@ -65,6 +65,7 @@ func TestCreateBatchFeature(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			metadataStore.EXPECT().GetGroupByName(ctx, tc.opt.GroupName).Return(&tc.group, nil)
 
 			if tc.group.Category == types.BatchFeatureCategory {

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-// Create meetadata of a feature group.
+// Create metadata of a feature group.
 func (s *OomStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) (int, error) {
 	if err := s.metadata.Refresh(); err != nil {
 		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -2,6 +2,7 @@ package oomstore
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -9,6 +10,9 @@ import (
 
 // Create meetadata of a feature group.
 func (s *OomStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) (int, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	entity, err := s.metadata.GetEntityByName(ctx, opt.EntityName)
 	if err != nil {
 		return 0, err
@@ -25,21 +29,31 @@ func (s *OomStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) (i
 
 // Get metadata of a feature group by ID.
 func (s *OomStore) GetGroup(ctx context.Context, id int) (*types.Group, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetGroup(ctx, id)
 }
 
 // Get metadata of a feature group by name.
 func (s *OomStore) GetGroupByName(ctx context.Context, name string) (*types.Group, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetGroupByName(ctx, name)
 }
 
 // List metadata of feature groups under the same entity.
 func (s *OomStore) ListGroup(ctx context.Context, entityID *int) types.GroupList {
+	_ = s.metadata.Refresh()
 	return s.metadata.ListGroup(ctx, entityID)
 }
 
 // Update metadata of a feature group.
 func (s *OomStore) UpdateGroup(ctx context.Context, opt types.UpdateGroupOpt) error {
+	if err := s.metadata.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return err

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -14,6 +14,9 @@ import (
 // Import a CSV data source into the feature store as a new revision.
 // In the future we want to support more diverse data sources.
 func (s *OomStore) Import(ctx context.Context, opt types.ImportOpt) (int, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err

--- a/pkg/oomstore/import_test.go
+++ b/pkg/oomstore/import_test.go
@@ -100,6 +100,7 @@ device,model,price
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			tc.mockFunc()
 			revisionID, err := store.Import(context.Background(), tc.opt)
 			assert.EqualError(t, err, tc.wantError.Error())
@@ -209,6 +210,7 @@ device,model,price
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			metadataStore.EXPECT().GetGroupByName(ctx, tc.opt.GroupName).Return(&types.Group{
 				ID:       1,
 				Name:     tc.opt.GroupName,

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -19,6 +19,9 @@ import (
 // Get point-in-time correct feature values for each entity row.
 // Currently, this API only supports batch features.
 func (s *OomStore) Join(ctx context.Context, opt types.JoinOpt) (*types.JoinResult, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
 		FeatureNames: &opt.FeatureNames,
 	})
@@ -30,7 +33,7 @@ func (s *OomStore) Join(ctx context.Context, opt types.JoinOpt) (*types.JoinResu
 		return nil, nil
 	}
 
-	entity, err := s.getSharedEntity(features)
+	entity, err := getSharedEntity(features)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oomstore/join_test.go
+++ b/pkg/oomstore/join_test.go
@@ -110,6 +110,7 @@ func TestJoin(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureNames: &tc.opt.FeatureNames}).Return(tc.features)
 			if tc.entity != nil {
 				for _, featureList := range tc.featureMap {

--- a/pkg/oomstore/online_query.go
+++ b/pkg/oomstore/online_query.go
@@ -15,7 +15,7 @@ func (s *OomStore) OnlineGet(ctx context.Context, opt types.OnlineGetOpt) (*type
 	features := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
 		FeatureNames: &opt.FeatureNames,
 	})
-	entity, err := s.getSharedEntity(features)
+	entity, err := getSharedEntity(features)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (s *OomStore) OnlineMultiGet(ctx context.Context, opt types.OnlineMultiGetO
 		return nil, nil
 	}
 
-	entity, err := s.getSharedEntity(features)
+	entity, err := getSharedEntity(features)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func groupFeaturesByRevisionID(features types.FeatureList) map[int]types.Feature
 	return featureMap
 }
 
-func (s *OomStore) getSharedEntity(features types.FeatureList) (*types.Entity, error) {
+func getSharedEntity(features types.FeatureList) (*types.Entity, error) {
 	m := make(map[int]*types.Entity)
 	for _, f := range features {
 		m[f.Group.EntityID] = f.Group.Entity

--- a/pkg/oomstore/revision.go
+++ b/pkg/oomstore/revision.go
@@ -2,21 +2,29 @@ package oomstore
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
 // List metadata of revisions of a same group.
 func (s *OomStore) ListRevision(ctx context.Context, groupID *int) types.RevisionList {
+	_ = s.metadata.Refresh()
 	return s.metadata.ListRevision(ctx, groupID)
 }
 
 // Get metadata of a revision by ID.
 func (s *OomStore) GetRevision(ctx context.Context, id int) (*types.Revision, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetRevision(ctx, id)
 }
 
 // Get metadata of a revision by group ID and revision.
 func (s *OomStore) GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error) {
+	if err := s.metadata.Refresh(); err != nil {
+		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	return s.metadata.GetRevisionBy(ctx, groupID, revision)
 }

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -16,6 +16,9 @@ import (
 // This helps get rid of unwanted out-of-memory errors,
 // where size of the particular revision outgrows memory limit of your machine.
 func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
+	if err := s.metadata.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh informer, err=%+v", err)
+	}
 	revision, err := s.GetRevision(ctx, opt.RevisionID)
 	if err != nil {
 		return err

--- a/pkg/oomstore/sync_test.go
+++ b/pkg/oomstore/sync_test.go
@@ -141,6 +141,7 @@ func TestSync(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			tc.mockFn()
 			require.Equal(t, tc.expectedError, store.Sync(ctx, tc.opt))
 		})


### PR DESCRIPTION
This PR does:
- refresh informer at the beginning of all non performance-critical APIs

close #591 