### PR TITLE
refactor: unify config paths

### DIFF
--- a/featctl/cmd/root.go
+++ b/featctl/cmd/root.go
@@ -15,7 +15,7 @@ import (
 )
 
 var cfgFile string
-var defaultCfgFile = filepath.Join(xdg.Home, ".config", "featctl", "config.yaml")
+var defaultCfgFile = filepath.Join(xdg.Home, ".config", "oomstore", "config.yaml")
 
 var oomStoreCfg types.OomStoreConfig
 

--- a/oomd/root.go
+++ b/oomd/root.go
@@ -21,7 +21,7 @@ import (
 )
 
 var cfgFile string
-var defaultCfgFile = filepath.Join(xdg.Home, ".config", "oomd", "config.yaml")
+var defaultCfgFile = filepath.Join(xdg.Home, ".config", "oomstore", "config.yaml")
 
 var oomStoreCfg types.OomStoreConfig
 var port int


### PR DESCRIPTION
Let `featctl` and `oomd` share the same config. 