### PR TITLE
Jinghan/refactor return type of API Export

### DIFF
--- a/internal/database/offline/mock_offline/store.go
+++ b/internal/database/offline/mock_offline/store.go
@@ -51,11 +51,11 @@ func (mr *MockStoreMockRecorder) Close() *gomock.Call {
 }
 
 // Export mocks base method.
-func (m *MockStore) Export(ctx context.Context, opt offline.ExportOpt) (<-chan *types.ExportRecord, error) {
+func (m *MockStore) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Export", ctx, opt)
-	ret0, _ := ret[0].(<-chan *types.ExportRecord)
-	ret1, _ := ret[1].(error)
+	ret0, _ := ret[0].(<-chan types.ExportRecord)
+	ret1, _ := ret[1].(<-chan error)
 	return ret0, ret1
 }
 

--- a/internal/database/offline/store.go
+++ b/internal/database/offline/store.go
@@ -9,7 +9,7 @@ import (
 
 type Store interface {
 	Join(ctx context.Context, opt JoinOpt) (*types.JoinResult, error)
-	Export(ctx context.Context, opt ExportOpt) (<-chan *types.ExportRecord, error)
+	Export(ctx context.Context, opt ExportOpt) (<-chan types.ExportRecord, <-chan error)
 	Import(ctx context.Context, opt ImportOpt) (int64, error)
 
 	TypeTag(dbType string) (string, error)

--- a/internal/database/offline/test_impl/export.go
+++ b/internal/database/offline/test_impl/export.go
@@ -58,14 +58,13 @@ func TestExport(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			actual, err := store.Export(ctx, tc.opt)
-			assert.NoError(t, err)
+			actual, errs := store.Export(ctx, tc.opt)
 			values := make([][]interface{}, 0)
-			for ele := range actual {
-				values = append(values, ele.Record)
-				assert.NoError(t, ele.Error)
+			for row := range actual {
+				values = append(values, row)
 			}
 			assert.Equal(t, tc.expected, values)
+			assert.NoError(t, <-errs)
 		})
 	}
 }

--- a/internal/database/offline/test_impl/import.go
+++ b/internal/database/offline/test_impl/import.go
@@ -56,17 +56,16 @@ func TestImport(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		_, err := store.Import(ctx, opt)
 		assert.NoError(t, err)
 
-		stream, err := store.Export(ctx, offline.ExportOpt{
+		stream, errch := store.Export(ctx, offline.ExportOpt{
 			DataTable:    dataTable,
 			EntityName:   entity.Name,
 			FeatureNames: []string{"model", "price"},
 		})
-		assert.NoError(t, err)
-
 		records := make([][]interface{}, 0)
-		for ele := range stream {
-			records = append(records, ele.Record)
+		for row := range stream {
+			records = append(records, row)
 		}
+		assert.NoError(t, <-errch)
 		sort.Slice(records, func(i, j int) bool {
 			return cast.ToString(records[i][0]) < cast.ToString(records[j][0])
 		})

--- a/internal/database/online/redis/import.go
+++ b/internal/database/online/redis/import.go
@@ -12,11 +12,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 	pipe := db.Pipeline()
 	defer pipe.Close()
 
-	for item := range opt.Stream {
-		if item.Error != nil {
-			return item.Error
-		}
-		record := item.Record
+	for record := range opt.ExportStream {
 		if len(record) != len(opt.FeatureList)+1 {
 			return fmt.Errorf("field count not matched, expected %d, got %d", len(opt.FeatureList)+1, len(record))
 		}
@@ -60,6 +56,9 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 		if _, err := pipe.Exec(ctx); err != nil {
 			return err
 		}
+	}
+	if opt.ExportError != nil {
+		return <-opt.ExportError
 	}
 	return nil
 }

--- a/internal/database/online/types.go
+++ b/internal/database/online/types.go
@@ -19,8 +19,9 @@ type MultiGetOpt struct {
 }
 
 type ImportOpt struct {
-	Revision    *types.Revision
-	Entity      *types.Entity
-	Stream      <-chan *types.ExportRecord
-	FeatureList types.FeatureList
+	Revision     *types.Revision
+	Entity       *types.Entity
+	ExportStream <-chan types.ExportRecord
+	ExportError  <-chan error
+	FeatureList  types.FeatureList
 }

--- a/pkg/oomstore/export.go
+++ b/pkg/oomstore/export.go
@@ -8,7 +8,19 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-// Export feature values of a particular revision.
+/*
+Export feature values of a particular revision.
+Usage Example:
+	exportResult, err := store.Export(ctx, opt)
+	if err != nil {
+		return err
+	}
+	for row := range exportResult.Data {
+		fmt.Println(cast.ToStringSlice([]interface{}(row)))
+	}
+	// Attention: call CheckStreamError after consuming exportResult.Data channel
+	return exportResult.CheckStreamError()
+*/
 func (s *OomStore) Export(ctx context.Context, opt types.ExportOpt) (*types.ExportResult, error) {
 	if err := s.metadata.Refresh(); err != nil {
 		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -38,20 +38,18 @@ func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
 	}
 
 	// Move data from offline to online store
-	stream, err := s.offline.Export(ctx, offline.ExportOpt{
+	exportStream, exportError := s.offline.Export(ctx, offline.ExportOpt{
 		DataTable:    revision.DataTable,
 		EntityName:   group.Entity.Name,
 		FeatureNames: features.Names(),
 	})
-	if err != nil {
-		return err
-	}
 
 	if err = s.online.Import(ctx, online.ImportOpt{
-		FeatureList: features,
-		Revision:    revision,
-		Entity:      group.Entity,
-		Stream:      stream,
+		FeatureList:  features,
+		Revision:     revision,
+		Entity:       group.Entity,
+		ExportStream: exportStream,
+		ExportError:  exportError,
 	}); err != nil {
 		return err
 	}

--- a/pkg/oomstore/sync_test.go
+++ b/pkg/oomstore/sync_test.go
@@ -73,7 +73,7 @@ func TestSync(t *testing.T) {
 				}, nil)
 				metadataStore.EXPECT().ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.Group.ID}).Return(features)
 
-				stream := make(chan *types.ExportRecord)
+				stream := make(chan types.ExportRecord)
 				offlineStore.EXPECT().Export(ctx, offline.ExportOpt{
 					DataTable:    "data-table-name",
 					EntityName:   "device",
@@ -86,7 +86,7 @@ func TestSync(t *testing.T) {
 					Entity: &types.Entity{
 						Name: "device",
 					},
-					Stream: stream,
+					ExportStream: stream,
 				}).Return(nil)
 
 				metadataStore.EXPECT().WithTransaction(ctx, gomock.Any()).Return(nil)
@@ -108,7 +108,7 @@ func TestSync(t *testing.T) {
 				}, nil)
 				metadataStore.EXPECT().ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.Group.ID}).Return(features)
 
-				stream := make(chan *types.ExportRecord)
+				stream := make(chan types.ExportRecord)
 				offlineStore.EXPECT().Export(ctx, offline.ExportOpt{
 					DataTable:    "data-table-name",
 					EntityName:   "device",
@@ -121,7 +121,7 @@ func TestSync(t *testing.T) {
 					Entity: &types.Entity{
 						Name: "device",
 					},
-					Stream: stream,
+					ExportStream: stream,
 				}).Return(nil)
 
 				metadataStore.EXPECT().WithTransaction(ctx, gomock.Any()).Return(nil)

--- a/pkg/oomstore/types/types.go
+++ b/pkg/oomstore/types/types.go
@@ -5,17 +5,14 @@ const (
 	StreamFeatureCategory = "stream"
 )
 
-type ExportRecord struct {
-	Record []interface{}
-	Error  error
+type ExportRecord []interface{}
+
+func (r ExportRecord) EntityKey() string {
+	return r[0].(string)
 }
 
-func (r *ExportRecord) EntityKey() string {
-	return r.Record[0].(string)
-}
-
-func (r *ExportRecord) ValueAt(i int) interface{} {
-	return r.Record[i+1]
+func (r ExportRecord) ValueAt(i int) interface{} {
+	return r[i+1]
 }
 
 type EntityRow struct {
@@ -26,4 +23,30 @@ type EntityRow struct {
 type JoinResult struct {
 	Header []string
 	Data   <-chan []interface{}
+}
+
+type ExportResult struct {
+	Header []string
+	Data   <-chan ExportRecord
+	error  <-chan error
+}
+
+func NewExportResult(header []string, data <-chan ExportRecord, error <-chan error) *ExportResult {
+	return &ExportResult{
+		Header: header,
+		Data:   data,
+		error:  error,
+	}
+}
+
+// ATTENTION: call this method only after you consume all elements
+// from Data channel; otherwise, it will block the Data channel.
+func (e *ExportResult) CheckStreamError() error {
+	if e == nil {
+		return nil
+	}
+	if e.error != nil {
+		return <-e.error
+	}
+	return nil
 }


### PR DESCRIPTION
This PR does:
- for offline method `Export`: separate record and error to two channels
- for online method `Import`: takes in error channel from export as an argument
- for oomstore API `Export`: wrap return results to struct `ExportResult`
- for oomstore API `Sync`: pass down export error channel
- for featctl cmd `export`: modify print out functions