### PR TITLE
Jinghan/implement oomstore API ExportByFile

### DIFF
--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -77,7 +77,7 @@ func (s *OomStore) JoinByFile(ctx context.Context, opt types.JoinByFileOpt) erro
 	if err != nil {
 		return err
 	}
-	return writeToFile(opt.OutputFilePath, joinResult)
+	return writeJoinResultToFile(opt.OutputFilePath, joinResult)
 }
 
 // key: group_name, value: slice of features
@@ -161,7 +161,7 @@ func GetEntityRowsFromInputFile(inputFilePath string) (<-chan types.EntityRow, e
 	return entityRows, nil
 }
 
-func writeToFile(outputFilePath string, joinResult *types.JoinResult) error {
+func writeJoinResultToFile(outputFilePath string, joinResult *types.JoinResult) error {
 	file, err := os.Create(outputFilePath)
 	if err != nil {
 		return err

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -40,6 +40,11 @@ type ExportOpt struct {
 	Limit        *uint64
 }
 
+type ExportByFileOpt struct {
+	ExportOpt
+	OutputFilePath string
+}
+
 type ImportOpt struct {
 	GroupName   string
 	Description string


### PR DESCRIPTION
This PR adds a new oomstore API `ExportByFile`, which exports feature values to a user-specified output file path.

related to #598 