### PR TITLE
Jinghan/use milliseconds revision

### DIFF
--- a/internal/database/offline/postgres/import.go
+++ b/internal/database/offline/postgres/import.go
@@ -63,7 +63,7 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 			revision = *opt.Revision
 		} else {
 			// generate revision using current timestamp
-			revision = time.Now().Unix()
+			revision = time.Now().UnixMilli()
 		}
 		return nil
 	})

--- a/oomctl/test/test_join.sh
+++ b/oomctl/test/test_join.sh
@@ -8,22 +8,23 @@ register_features
 # clean up the tmp file
 trap 'command rm -rf entity_rows.csv' EXIT INT TERM HUP
 
-before_unix_time=$(date +%s)
-echo "1,${before_unix_time}" >> entity_rows.csv
-echo "2,${before_unix_time}" >> entity_rows.csv
+before_unix_time_ms=$(date +%s000)
+echo "1,${before_unix_time_ms}" >> entity_rows.csv
+echo "2,${before_unix_time_ms}" >> entity_rows.csv
 sleep 1
 import_sample > /dev/null
-after_unix_time=$(date +%s)
-echo "1,${after_unix_time}" >> entity_rows.csv
-echo "2,${after_unix_time}" >> entity_rows.csv
+sleep 1
+after_unix_time_ms=$(date +%s000)
+echo "1,${after_unix_time_ms}" >> entity_rows.csv
+echo "2,${after_unix_time_ms}" >> entity_rows.csv
 
 case='oomctl join historical-feature'
 expected="
 entity_key,unix_time,model,price
-1,${after_unix_time},xiaomi-mix3,3999
-2,${after_unix_time},huawei-p40,5299
-1,${before_unix_time},,
-2,${before_unix_time},,
+1,${after_unix_time_ms},xiaomi-mix3,3999
+2,${after_unix_time_ms},huawei-p40,5299
+1,${before_unix_time_ms},,
+2,${before_unix_time_ms},,
 "
 
 actual=$(oomctl join \


### PR DESCRIPTION
Before, we store `revision` timestamp as seconds in database. 

Now, we switch to use milliseconds.

close #635 