### PR TITLE
Jinghan/add field `Values` to API ChannelJoin

### DIFF
--- a/internal/database/offline/types.go
+++ b/internal/database/offline/types.go
@@ -19,6 +19,7 @@ type JoinOpt struct {
 	EntityRows       <-chan types.EntityRow
 	FeatureMap       map[string]types.FeatureList
 	RevisionRangeMap map[string][]*metadata.RevisionRange
+	ValueNames       []string
 }
 
 type JoinOneGroupOpt struct {
@@ -27,6 +28,7 @@ type JoinOneGroupOpt struct {
 	RevisionRanges      []*metadata.RevisionRange
 	Entity              types.Entity
 	EntityRowsTableName string
+	ValueNames          []string
 }
 
 type ImportOpt struct {

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -59,6 +59,7 @@ func (s *OomStore) ChannelJoin(ctx context.Context, opt types.ChannelJoinOpt) (*
 		EntityRows:       opt.EntityRows,
 		FeatureMap:       featureMap,
 		RevisionRangeMap: revisionRangeMap,
+		ValueNames:       opt.ValueNames,
 	})
 }
 

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -84,6 +84,7 @@ type OnlineMultiGetOpt struct {
 type ChannelJoinOpt struct {
 	FeatureNames []string
 	EntityRows   <-chan EntityRow
+	ValueNames   []string
 }
 
 type JoinOpt struct {

--- a/pkg/oomstore/types/types.go
+++ b/pkg/oomstore/types/types.go
@@ -16,8 +16,9 @@ func (r ExportRecord) ValueAt(i int) interface{} {
 }
 
 type EntityRow struct {
-	EntityKey string `db:"entity_key"`
-	UnixMilli int64  `db:"unix_milli"`
+	EntityKey string
+	UnixMilli int64
+	Values    []string
 }
 
 type JoinResult struct {


### PR DESCRIPTION
This PR refactors oomstore API `ChannelJoin`:
- add field `Values` to `types.EntityRow`
- refactor offline db method `Join`

TODO:
- refactor oomstore API `Join`
- refactor oomcli command `join`

related to #533 