### PR TITLE
Jinghan/use db-based methods for GetEntity(ByName) and ListEntity

### DIFF
--- a/internal/database/metadata/informer/informer.go
+++ b/internal/database/metadata/informer/informer.go
@@ -94,26 +94,6 @@ func (f *Informer) Cache() *Cache {
 }
 
 // Get
-func (f *Informer) CacheGetEntity(ctx context.Context, id int) (*types.Entity, error) {
-	if entity := f.Cache().Entities.Find(func(e *types.Entity) bool {
-		return e.ID == id
-	}); entity == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("feature entity %d not found", id))
-	} else {
-		return entity.Copy(), nil
-	}
-}
-
-func (f *Informer) CacheGetEntityByName(ctx context.Context, name string) (*types.Entity, error) {
-	if entity := f.Cache().Entities.Find(func(e *types.Entity) bool {
-		return e.Name == name
-	}); entity == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("feature entity '%s' not found", name))
-	} else {
-		return entity.Copy(), nil
-	}
-}
-
 func (f *Informer) CacheGetFeature(ctx context.Context, id int) (*types.Feature, error) {
 	if feature := f.Cache().Features.Find(func(f *types.Feature) bool {
 		return f.ID == id
@@ -175,10 +155,6 @@ func (f *Informer) CacheGetRevisionBy(ctx context.Context, groupID int, revision
 }
 
 // List
-func (f *Informer) CacheListEntity(ctx context.Context) types.EntityList {
-	return f.Cache().Entities.List().Copy()
-}
-
 func (f *Informer) CacheListFeature(ctx context.Context, opt metadata.ListFeatureOpt) types.FeatureList {
 	return f.Cache().Features.List(opt).Copy()
 }

--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -37,36 +37,6 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// CacheGetEntity mocks base method.
-func (m *MockStore) CacheGetEntity(ctx context.Context, id int) (*types.Entity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetEntity", ctx, id)
-	ret0, _ := ret[0].(*types.Entity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetEntity indicates an expected call of CacheGetEntity.
-func (mr *MockStoreMockRecorder) CacheGetEntity(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetEntity", reflect.TypeOf((*MockStore)(nil).CacheGetEntity), ctx, id)
-}
-
-// CacheGetEntityByName mocks base method.
-func (m *MockStore) CacheGetEntityByName(ctx context.Context, name string) (*types.Entity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetEntityByName", ctx, name)
-	ret0, _ := ret[0].(*types.Entity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetEntityByName indicates an expected call of CacheGetEntityByName.
-func (mr *MockStoreMockRecorder) CacheGetEntityByName(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetEntityByName", reflect.TypeOf((*MockStore)(nil).CacheGetEntityByName), ctx, name)
-}
-
 // CacheGetFeature mocks base method.
 func (m *MockStore) CacheGetFeature(ctx context.Context, id int) (*types.Feature, error) {
 	m.ctrl.T.Helper()
@@ -155,20 +125,6 @@ func (m *MockStore) CacheGetRevisionBy(ctx context.Context, groupID int, revisio
 func (mr *MockStoreMockRecorder) CacheGetRevisionBy(ctx, groupID, revision interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetRevisionBy", reflect.TypeOf((*MockStore)(nil).CacheGetRevisionBy), ctx, groupID, revision)
-}
-
-// CacheListEntity mocks base method.
-func (m *MockStore) CacheListEntity(ctx context.Context) types.EntityList {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheListEntity", ctx)
-	ret0, _ := ret[0].(types.EntityList)
-	return ret0
-}
-
-// CacheListEntity indicates an expected call of CacheListEntity.
-func (mr *MockStoreMockRecorder) CacheListEntity(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheListEntity", reflect.TypeOf((*MockStore)(nil).CacheListEntity), ctx)
 }
 
 // CacheListFeature mocks base method.
@@ -500,36 +456,6 @@ func (m *MockReadStore) EXPECT() *MockReadStoreMockRecorder {
 	return m.recorder
 }
 
-// CacheGetEntity mocks base method.
-func (m *MockReadStore) CacheGetEntity(ctx context.Context, id int) (*types.Entity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetEntity", ctx, id)
-	ret0, _ := ret[0].(*types.Entity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetEntity indicates an expected call of CacheGetEntity.
-func (mr *MockReadStoreMockRecorder) CacheGetEntity(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetEntity", reflect.TypeOf((*MockReadStore)(nil).CacheGetEntity), ctx, id)
-}
-
-// CacheGetEntityByName mocks base method.
-func (m *MockReadStore) CacheGetEntityByName(ctx context.Context, name string) (*types.Entity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetEntityByName", ctx, name)
-	ret0, _ := ret[0].(*types.Entity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetEntityByName indicates an expected call of CacheGetEntityByName.
-func (mr *MockReadStoreMockRecorder) CacheGetEntityByName(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetEntityByName", reflect.TypeOf((*MockReadStore)(nil).CacheGetEntityByName), ctx, name)
-}
-
 // CacheGetFeature mocks base method.
 func (m *MockReadStore) CacheGetFeature(ctx context.Context, id int) (*types.Feature, error) {
 	m.ctrl.T.Helper()
@@ -618,20 +544,6 @@ func (m *MockReadStore) CacheGetRevisionBy(ctx context.Context, groupID int, rev
 func (mr *MockReadStoreMockRecorder) CacheGetRevisionBy(ctx, groupID, revision interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetRevisionBy", reflect.TypeOf((*MockReadStore)(nil).CacheGetRevisionBy), ctx, groupID, revision)
-}
-
-// CacheListEntity mocks base method.
-func (m *MockReadStore) CacheListEntity(ctx context.Context) types.EntityList {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheListEntity", ctx)
-	ret0, _ := ret[0].(types.EntityList)
-	return ret0
-}
-
-// CacheListEntity indicates an expected call of CacheListEntity.
-func (mr *MockReadStoreMockRecorder) CacheListEntity(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheListEntity", reflect.TypeOf((*MockReadStore)(nil).CacheListEntity), ctx)
 }
 
 // CacheListFeature mocks base method.

--- a/internal/database/metadata/postgres/entity_test.go
+++ b/internal/database/metadata/postgres/entity_test.go
@@ -21,7 +21,3 @@ func TestUpdateEntity(t *testing.T) {
 func TestListEntity(t *testing.T) {
 	test_impl.TestListEntity(t, prepareStore)
 }
-
-func TestCacheListEntity(t *testing.T) {
-	test_impl.TestCacheListEntity(t, prepareStore)
-}

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -18,9 +18,6 @@ type Store interface {
 type ReadStore interface {
 	GetEntity(ctx context.Context, id int) (*types.Entity, error)
 	GetEntityByName(ctx context.Context, name string) (*types.Entity, error)
-	CacheGetEntity(ctx context.Context, id int) (*types.Entity, error)
-	CacheGetEntityByName(ctx context.Context, name string) (*types.Entity, error)
-	CacheListEntity(ctx context.Context) types.EntityList
 	ListEntity(ctx context.Context, entityIDs *[]int) (types.EntityList, error)
 
 	GetFeature(ctx context.Context, id int) (*types.Feature, error)

--- a/internal/database/metadata/test_impl/entity.go
+++ b/internal/database/metadata/test_impl/entity.go
@@ -60,33 +60,6 @@ func TestGetEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.EqualError(t, err, "feature entity 0 not found")
 }
 
-func TestCacheGetEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
-	ctx, store := prepareStore(t)
-	defer store.Close()
-
-	opt := metadata.CreateEntityOpt{
-		CreateEntityOpt: types.CreateEntityOpt{
-			EntityName:  "device",
-			Length:      32,
-			Description: "description",
-		},
-	}
-
-	id, err := store.CreateEntity(ctx, opt)
-	require.NoError(t, err)
-
-	require.NoError(t, store.Refresh())
-
-	entity, err := store.CacheGetEntity(ctx, id)
-	require.NoError(t, err)
-	require.Equal(t, opt.EntityName, entity.Name)
-	require.Equal(t, opt.Length, entity.Length)
-	require.Equal(t, opt.Description, entity.Description)
-
-	_, err = store.CacheGetEntity(ctx, 0)
-	require.EqualError(t, err, "feature entity 0 not found")
-}
-
 func TestUpdateEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
@@ -107,7 +80,7 @@ func TestUpdateEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 
 	require.NoError(t, store.Refresh())
 
-	entity, err := store.CacheGetEntity(ctx, id)
+	entity, err := store.GetEntity(ctx, id)
 	require.NoError(t, err)
 	require.Equal(t, entity.Description, "new description")
 
@@ -115,43 +88,6 @@ func TestUpdateEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 		EntityID:       id + 1,
 		NewDescription: stringPtr("new description"),
 	}))
-}
-
-func TestCacheListEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
-	ctx, store := prepareStore(t)
-	defer store.Close()
-
-	require.NoError(t, store.Refresh())
-
-	entities := store.CacheListEntity(ctx)
-	require.Equal(t, 0, len(entities))
-
-	_, err := store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		CreateEntityOpt: types.CreateEntityOpt{
-			EntityName:  "device",
-			Length:      32,
-			Description: "description",
-		},
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, store.Refresh())
-
-	entities = store.CacheListEntity(ctx)
-	require.Equal(t, 1, len(entities))
-	_, err = store.CreateEntity(ctx, metadata.CreateEntityOpt{
-		CreateEntityOpt: types.CreateEntityOpt{
-			EntityName:  "user",
-			Length:      16,
-			Description: "description",
-		},
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, store.Refresh())
-
-	entities = store.CacheListEntity(ctx)
-	require.Equal(t, 2, len(entities))
 }
 
 func TestListEntity(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {

--- a/oomcli/cmd/list_entity.go
+++ b/oomcli/cmd/list_entity.go
@@ -22,11 +22,14 @@ var listEntityCmd = &cobra.Command{
 		oomStore := mustOpenOomStore(ctx, oomStoreCfg)
 		defer oomStore.Close()
 
-		entities := oomStore.ListEntity(ctx)
+		entities, err := oomStore.ListEntity(ctx)
+		if err != nil {
+			log.Fatalf("failed listing entities, error %v\n", err)
+		}
 
 		// print entities to stdout
 		if err := printEntities(entities, *listOutput); err != nil {
-			log.Fatalf("failing printing entities, error %v\n", err)
+			log.Fatalf("failed printing entities, error %v\n", err)
 		}
 	},
 }

--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -40,7 +40,7 @@ func (s *OomStore) Apply(ctx context.Context, opt apply.ApplyOpt) error {
 		for _, group := range stage.NewGroups {
 			if _, exist := entityMp[group.EntityName]; !exist {
 				var entity *types.Entity
-				if entity, err = s.metadata.CacheGetEntityByName(c, group.EntityName); err != nil {
+				if entity, err = s.metadata.GetEntityByName(c, group.EntityName); err != nil {
 					return err
 				}
 				entityMp[group.EntityName] = entity.ID
@@ -77,7 +77,7 @@ func (s *OomStore) applyEntity(ctx context.Context, txStore metadata.WriteStore,
 		return 0, err
 	}
 
-	entity, err := s.metadata.CacheGetEntityByName(ctx, newEntity.Name)
+	entity, err := s.metadata.GetEntityByName(ctx, newEntity.Name)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return 0, err

--- a/pkg/oomstore/entity.go
+++ b/pkg/oomstore/entity.go
@@ -2,7 +2,6 @@ package oomstore
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -10,31 +9,21 @@ import (
 
 // Get metadata of an entity by ID.
 func (s *OomStore) GetEntity(ctx context.Context, id int) (*types.Entity, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	return s.metadata.CacheGetEntity(ctx, id)
+	return s.metadata.GetEntity(ctx, id)
 }
 
 // Get metadata of an entity by name.
 func (s *OomStore) GetEntityByName(ctx context.Context, name string) (*types.Entity, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	return s.metadata.CacheGetEntityByName(ctx, name)
+	return s.metadata.GetEntityByName(ctx, name)
 }
 
 // List metadata of all entities.
-func (s *OomStore) ListEntity(ctx context.Context) types.EntityList {
-	_ = s.metadata.Refresh()
-	return s.metadata.CacheListEntity(ctx)
+func (s *OomStore) ListEntity(ctx context.Context) (types.EntityList, error) {
+	return s.metadata.ListEntity(ctx, nil)
 }
 
 // Create metadata for an entity.
 func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) (int, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
 	return s.metadata.CreateEntity(ctx, metadata.CreateEntityOpt{
 		CreateEntityOpt: opt,
 	})
@@ -42,10 +31,7 @@ func (s *OomStore) CreateEntity(ctx context.Context, opt types.CreateEntityOpt) 
 
 // Update metadata for an entity.
 func (s *OomStore) UpdateEntity(ctx context.Context, opt types.UpdateEntityOpt) error {
-	if err := s.metadata.Refresh(); err != nil {
-		return fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	entity, err := s.metadata.CacheGetEntityByName(ctx, opt.EntityName)
+	entity, err := s.metadata.GetEntityByName(ctx, opt.EntityName)
 	if err != nil {
 		return err
 	}

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -33,7 +33,7 @@ func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (t
 		FeatureNames: opt.FeatureNames,
 	}
 	if opt.EntityName != nil {
-		entity, err := s.metadata.CacheGetEntityByName(ctx, *opt.EntityName)
+		entity, err := s.metadata.GetEntityByName(ctx, *opt.EntityName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -10,10 +10,7 @@ import (
 
 // Create metadata of a feature group.
 func (s *OomStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) (int, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	entity, err := s.metadata.CacheGetEntityByName(ctx, opt.EntityName)
+	entity, err := s.metadata.GetEntityByName(ctx, opt.EntityName)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This PR does: 
- replace `CacheGetEntity`, `CacheGetEntityByName`, `CacheListEntity` by db-based methods
- delete entity's informer-based methods

related to #661 