### PR TITLE
Jinghan/use db-based methods for GetGroup(ByName) and ListGroup

### DIFF
--- a/internal/database/metadata/informer/informer.go
+++ b/internal/database/metadata/informer/informer.go
@@ -114,26 +114,6 @@ func (f *Informer) CacheGetFeatureByName(ctx context.Context, name string) (*typ
 	}
 }
 
-func (f *Informer) CacheGetGroup(ctx context.Context, id int) (*types.Group, error) {
-	if group := f.Cache().Groups.Find(func(g *types.Group) bool {
-		return g.ID == id
-	}); group == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("feature group %d not found", id))
-	} else {
-		return group.Copy(), nil
-	}
-}
-
-func (f *Informer) CacheGetGroupByName(ctx context.Context, name string) (*types.Group, error) {
-	if group := f.Cache().Groups.Find(func(g *types.Group) bool {
-		return g.Name == name
-	}); group == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("feature group '%s' not found", name))
-	} else {
-		return group.Copy(), nil
-	}
-}
-
 func (f *Informer) CacheGetRevision(ctx context.Context, id int) (*types.Revision, error) {
 	if revision := f.Cache().Revisions.Find(func(r *types.Revision) bool {
 		return r.ID == id
@@ -157,10 +137,6 @@ func (f *Informer) CacheGetRevisionBy(ctx context.Context, groupID int, revision
 // List
 func (f *Informer) CacheListFeature(ctx context.Context, opt metadata.ListFeatureOpt) types.FeatureList {
 	return f.Cache().Features.List(opt).Copy()
-}
-
-func (f *Informer) CacheListGroup(ctx context.Context, entityID *int) types.GroupList {
-	return f.Cache().Groups.List(entityID).Copy()
 }
 
 func (f *Informer) CacheListRevision(ctx context.Context, groupID *int) types.RevisionList {

--- a/internal/database/metadata/informer/informer_test.go
+++ b/internal/database/metadata/informer/informer_test.go
@@ -50,18 +50,17 @@ func TestInformer(t *testing.T) {
 	ctx, informer := prepareInformer(t)
 	defer informer.Close()
 
-	group, err := informer.CacheGetGroup(ctx, 100)
+	feature, err := informer.CacheGetFeature(ctx, 1)
 	require.NoError(t, err)
 
-	require.Equal(t, 100, group.ID)
-	require.Equal(t, "group", group.Name)
-	require.Equal(t, "batch", group.Category)
-	require.Equal(t, 1, group.EntityID)
+	require.Equal(t, 1, feature.ID)
+	require.Equal(t, "price", feature.Name)
+	require.Equal(t, 100, feature.GroupID)
 
-	require.NotNil(t, group.Entity)
-	require.Equal(t, 1, group.Entity.ID)
-	require.Equal(t, 10, group.Entity.Length)
-	require.Equal(t, "entity", group.Entity.Name)
+	require.NotNil(t, feature.Group)
+	require.Equal(t, 100, feature.Group.ID)
+	require.Equal(t, 1, feature.Group.Entity.ID)
+	require.Equal(t, "entity", feature.Group.Entity.Name)
 }
 
 func TestInformerDeepCopyGet(t *testing.T) {

--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -67,36 +67,6 @@ func (mr *MockStoreMockRecorder) CacheGetFeatureByName(ctx, name interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetFeatureByName", reflect.TypeOf((*MockStore)(nil).CacheGetFeatureByName), ctx, name)
 }
 
-// CacheGetGroup mocks base method.
-func (m *MockStore) CacheGetGroup(ctx context.Context, id int) (*types.Group, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetGroup", ctx, id)
-	ret0, _ := ret[0].(*types.Group)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetGroup indicates an expected call of CacheGetGroup.
-func (mr *MockStoreMockRecorder) CacheGetGroup(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetGroup", reflect.TypeOf((*MockStore)(nil).CacheGetGroup), ctx, id)
-}
-
-// CacheGetGroupByName mocks base method.
-func (m *MockStore) CacheGetGroupByName(ctx context.Context, name string) (*types.Group, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetGroupByName", ctx, name)
-	ret0, _ := ret[0].(*types.Group)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetGroupByName indicates an expected call of CacheGetGroupByName.
-func (mr *MockStoreMockRecorder) CacheGetGroupByName(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetGroupByName", reflect.TypeOf((*MockStore)(nil).CacheGetGroupByName), ctx, name)
-}
-
 // CacheGetRevision mocks base method.
 func (m *MockStore) CacheGetRevision(ctx context.Context, id int) (*types.Revision, error) {
 	m.ctrl.T.Helper()
@@ -139,20 +109,6 @@ func (m *MockStore) CacheListFeature(ctx context.Context, opt metadata.ListFeatu
 func (mr *MockStoreMockRecorder) CacheListFeature(ctx, opt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheListFeature", reflect.TypeOf((*MockStore)(nil).CacheListFeature), ctx, opt)
-}
-
-// CacheListGroup mocks base method.
-func (m *MockStore) CacheListGroup(ctx context.Context, entityID *int) types.GroupList {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheListGroup", ctx, entityID)
-	ret0, _ := ret[0].(types.GroupList)
-	return ret0
-}
-
-// CacheListGroup indicates an expected call of CacheListGroup.
-func (mr *MockStoreMockRecorder) CacheListGroup(ctx, entityID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheListGroup", reflect.TypeOf((*MockStore)(nil).CacheListGroup), ctx, entityID)
 }
 
 // CacheListRevision mocks base method.
@@ -486,36 +442,6 @@ func (mr *MockReadStoreMockRecorder) CacheGetFeatureByName(ctx, name interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetFeatureByName", reflect.TypeOf((*MockReadStore)(nil).CacheGetFeatureByName), ctx, name)
 }
 
-// CacheGetGroup mocks base method.
-func (m *MockReadStore) CacheGetGroup(ctx context.Context, id int) (*types.Group, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetGroup", ctx, id)
-	ret0, _ := ret[0].(*types.Group)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetGroup indicates an expected call of CacheGetGroup.
-func (mr *MockReadStoreMockRecorder) CacheGetGroup(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetGroup", reflect.TypeOf((*MockReadStore)(nil).CacheGetGroup), ctx, id)
-}
-
-// CacheGetGroupByName mocks base method.
-func (m *MockReadStore) CacheGetGroupByName(ctx context.Context, name string) (*types.Group, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetGroupByName", ctx, name)
-	ret0, _ := ret[0].(*types.Group)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetGroupByName indicates an expected call of CacheGetGroupByName.
-func (mr *MockReadStoreMockRecorder) CacheGetGroupByName(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetGroupByName", reflect.TypeOf((*MockReadStore)(nil).CacheGetGroupByName), ctx, name)
-}
-
 // CacheGetRevision mocks base method.
 func (m *MockReadStore) CacheGetRevision(ctx context.Context, id int) (*types.Revision, error) {
 	m.ctrl.T.Helper()
@@ -558,20 +484,6 @@ func (m *MockReadStore) CacheListFeature(ctx context.Context, opt metadata.ListF
 func (mr *MockReadStoreMockRecorder) CacheListFeature(ctx, opt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheListFeature", reflect.TypeOf((*MockReadStore)(nil).CacheListFeature), ctx, opt)
-}
-
-// CacheListGroup mocks base method.
-func (m *MockReadStore) CacheListGroup(ctx context.Context, entityID *int) types.GroupList {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheListGroup", ctx, entityID)
-	ret0, _ := ret[0].(types.GroupList)
-	return ret0
-}
-
-// CacheListGroup indicates an expected call of CacheListGroup.
-func (mr *MockReadStoreMockRecorder) CacheListGroup(ctx, entityID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheListGroup", reflect.TypeOf((*MockReadStore)(nil).CacheListGroup), ctx, entityID)
 }
 
 // CacheListRevision mocks base method.

--- a/internal/database/metadata/postgres/group.go
+++ b/internal/database/metadata/postgres/group.go
@@ -68,14 +68,14 @@ func getGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, id int) (*types
 	var group types.Group
 	query := `SELECT * FROM feature_group WHERE id = $1`
 	if err := sqlxCtx.GetContext(ctx, &group, query, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errdefs.NotFound(fmt.Errorf("feature group %d not found", id))
+		}
 		return nil, err
 	}
 
 	entity, err := getEntity(ctx, sqlxCtx, group.EntityID)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(fmt.Errorf("feature group %d not found", id))
-		}
 		return nil, err
 	}
 	group.Entity = entity
@@ -86,14 +86,14 @@ func getGroupByName(ctx context.Context, sqlxCtx metadata.SqlxContext, name stri
 	var group types.Group
 	query := `SELECT * FROM feature_group WHERE name = $1`
 	if err := sqlxCtx.GetContext(ctx, &group, query, name); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errdefs.NotFound(fmt.Errorf("feature group %s not found", name))
+		}
 		return nil, err
 	}
 
 	entity, err := getEntity(ctx, sqlxCtx, group.EntityID)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(fmt.Errorf("feature group %s not found", name))
-		}
 		return nil, err
 	}
 	group.Entity = entity

--- a/internal/database/metadata/postgres/group_test.go
+++ b/internal/database/metadata/postgres/group_test.go
@@ -6,16 +6,8 @@ import (
 	"github.com/oom-ai/oomstore/internal/database/metadata/test_impl"
 )
 
-func TestCacheGetGroup(t *testing.T) {
-	test_impl.TestCacheGetGroup(t, prepareStore)
-}
-
 func TestGetGroup(t *testing.T) {
 	test_impl.TestGetGroup(t, prepareStore)
-}
-
-func TestCacheListGroup(t *testing.T) {
-	test_impl.TestCacheListGroup(t, prepareStore)
 }
 
 func TestListGroup(t *testing.T) {

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -25,10 +25,6 @@ type ReadStore interface {
 	CacheGetFeatureByName(ctx context.Context, name string) (*types.Feature, error)
 	CacheListFeature(ctx context.Context, opt ListFeatureOpt) types.FeatureList
 
-	CacheGetGroup(ctx context.Context, id int) (*types.Group, error)
-	CacheGetGroupByName(ctx context.Context, name string) (*types.Group, error)
-	CacheListGroup(ctx context.Context, entityID *int) types.GroupList
-
 	GetGroup(ctx context.Context, id int) (*types.Group, error)
 	GetGroupByName(ctx context.Context, name string) (*types.Group, error)
 	ListGroup(ctx context.Context, entityID *int) (types.GroupList, error)

--- a/internal/database/metadata/test_impl/group.go
+++ b/internal/database/metadata/test_impl/group.go
@@ -23,36 +23,6 @@ func prepareEntity(t *testing.T, ctx context.Context, store metadata.Store, name
 	return entityID
 }
 
-func TestCacheGetGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
-	ctx, store := prepareStore(t)
-	defer store.Close()
-
-	entityID := prepareEntity(t, ctx, store, "device")
-
-	opt := metadata.CreateGroupOpt{
-		GroupName:   "device_info",
-		EntityID:    entityID,
-		Description: "description",
-		Category:    types.BatchFeatureCategory,
-	}
-	id, err := store.CreateGroup(ctx, opt)
-	require.NoError(t, err)
-
-	require.NoError(t, store.Refresh())
-
-	// get non-exist feature group
-	_, err = store.CacheGetGroup(ctx, 0)
-	require.Error(t, err)
-
-	// get existing feature group
-	group, err := store.CacheGetGroup(ctx, id)
-	require.NoError(t, err)
-	require.Equal(t, opt.GroupName, group.Name)
-	require.Equal(t, opt.EntityID, group.EntityID)
-	require.Equal(t, opt.Description, group.Description)
-	require.Equal(t, opt.Category, group.Category)
-}
-
 func TestGetGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
@@ -87,46 +57,6 @@ func TestGetGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.Equal(t, opt.EntityID, group.EntityID)
 	require.Equal(t, opt.Description, group.Description)
 	require.Equal(t, opt.Category, group.Category)
-}
-
-func TestCacheListGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
-	ctx, store := prepareStore(t)
-	defer store.Close()
-
-	deviceEntityID := prepareEntity(t, ctx, store, "device")
-	userEntityID := prepareEntity(t, ctx, store, "user")
-
-	deviceOpt := metadata.CreateGroupOpt{
-		GroupName:   "device_info",
-		EntityID:    deviceEntityID,
-		Description: "description",
-		Category:    types.BatchFeatureCategory,
-	}
-	userBaseOpt := metadata.CreateGroupOpt{
-		GroupName:   "user_info",
-		EntityID:    userEntityID,
-		Description: "description",
-		Category:    types.BatchFeatureCategory,
-	}
-	userBehaviorOpt := metadata.CreateGroupOpt{
-		GroupName:   "user_profile",
-		EntityID:    userEntityID,
-		Description: "description",
-		Category:    types.BatchFeatureCategory,
-	}
-	deviceGroupID, err := store.CreateGroup(ctx, deviceOpt)
-	require.NoError(t, err)
-	userGroupID, err := store.CreateGroup(ctx, userBaseOpt)
-	require.NoError(t, err)
-	_, err = store.CreateGroup(ctx, userBehaviorOpt)
-	require.NoError(t, err)
-
-	require.NoError(t, store.Refresh())
-
-	require.Equal(t, 1, len(store.CacheListGroup(ctx, &deviceGroupID)))
-	require.Equal(t, 2, len(store.CacheListGroup(ctx, &userGroupID)))
-	require.Equal(t, 3, len(store.CacheListGroup(ctx, nil)))
-	require.Equal(t, 0, len(store.CacheListGroup(ctx, intPtr(0))))
 }
 
 func TestListGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -17,7 +17,7 @@ func TestCreateRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	defer store.Close()
 
 	_, groupID := prepareEntityAndGroup(t, ctx, store)
-	group, err := store.CacheGetGroup(ctx, groupID)
+	group, err := store.GetGroup(ctx, groupID)
 	require.NoError(t, err)
 	opt := metadata.CreateRevisionOpt{
 		GroupID:     groupID,
@@ -155,7 +155,7 @@ func TestGetRevision(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.NoError(t, err)
 
 	require.NoError(t, store.Refresh())
-	group, err := store.CacheGetGroup(ctx, groupID)
+	group, err := store.GetGroup(ctx, groupID)
 	require.NoError(t, err)
 
 	revision := types.Revision{
@@ -217,7 +217,7 @@ func TestGetRevisionBy(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.NoError(t, err)
 
 	require.NoError(t, store.Refresh())
-	group, err := store.CacheGetGroup(ctx, groupID)
+	group, err := store.GetGroup(ctx, groupID)
 	require.NoError(t, err)
 
 	revision := types.Revision{
@@ -355,7 +355,7 @@ func prepareRevisions(t *testing.T, ctx context.Context, store metadata.Store) (
 	require.NoError(t, err)
 
 	require.NoError(t, store.Refresh())
-	group, err := store.CacheGetGroup(ctx, groupID)
+	group, err := store.GetGroup(ctx, groupID)
 	require.NoError(t, err)
 
 	revision1 := &types.Revision{

--- a/oomcli/cmd/list_group.go
+++ b/oomcli/cmd/list_group.go
@@ -43,7 +43,10 @@ var listGroupCmd = &cobra.Command{
 			entityID = &entity.ID
 		}
 
-		groups := oomStore.ListGroup(ctx, entityID)
+		groups, err := oomStore.ListGroup(ctx, entityID)
+		if err != nil {
+			log.Fatalf("failed listing feature groups, error %v\n", err)
+		}
 		if err := printGroups(groups, *listOutput); err != nil {
 			log.Fatalf("failed printing feature groups, error %v\n", err)
 		}

--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -57,7 +57,7 @@ func (s *OomStore) Apply(ctx context.Context, opt apply.ApplyOpt) error {
 		for _, feature := range stage.NewFeatures {
 			if _, exist := groupMp[feature.GroupName]; !exist {
 				var group *types.Group
-				if group, err = s.metadata.CacheGetGroupByName(ctx, feature.GroupName); err != nil {
+				if group, err = s.metadata.GetGroupByName(ctx, feature.GroupName); err != nil {
 					return err
 				}
 				groupMp[feature.GroupName] = group.ID
@@ -109,7 +109,7 @@ func (s *OomStore) applyGroup(ctx context.Context, txStore metadata.WriteStore, 
 		return 0, err
 	}
 
-	group, err := s.metadata.CacheGetGroupByName(ctx, newGroup.Name)
+	group, err := s.metadata.GetGroupByName(ctx, newGroup.Name)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
 			return 0, err

--- a/pkg/oomstore/export_test.go
+++ b/pkg/oomstore/export_test.go
@@ -97,7 +97,7 @@ func TestChannelExport(t *testing.T) {
 			}
 
 			metadataStore.EXPECT().CacheGetRevision(ctx, tc.opt.RevisionID).Return(&revision, nil)
-			metadataStore.EXPECT().CacheGetGroupByName(ctx, "device_info").Return(&types.Group{
+			metadataStore.EXPECT().GetGroupByName(ctx, "device_info").Return(&types.Group{
 				Name: "device_info",
 				ID:   1,
 			}, nil)

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -40,7 +40,7 @@ func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (t
 		metadataOpt.EntityID = &entity.ID
 	}
 	if opt.GroupName != nil {
-		group, err := s.metadata.CacheGetGroupByName(ctx, *opt.GroupName)
+		group, err := s.metadata.GetGroupByName(ctx, *opt.GroupName)
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatu
 	if err := s.metadata.Refresh(); err != nil {
 		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
 	}
-	group, err := s.metadata.CacheGetGroupByName(ctx, opt.GroupName)
+	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/oomstore/feature_test.go
+++ b/pkg/oomstore/feature_test.go
@@ -66,7 +66,7 @@ func TestCreateBatchFeature(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
-			metadataStore.EXPECT().CacheGetGroupByName(ctx, tc.opt.GroupName).Return(&tc.group, nil)
+			metadataStore.EXPECT().GetGroupByName(ctx, tc.opt.GroupName).Return(&tc.group, nil)
 
 			if tc.group.Category == types.BatchFeatureCategory {
 				metadataOpt := metadata.CreateFeatureOpt{

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -2,7 +2,6 @@ package oomstore
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -26,32 +25,22 @@ func (s *OomStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) (i
 
 // Get metadata of a feature group by ID.
 func (s *OomStore) GetGroup(ctx context.Context, id int) (*types.Group, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	return s.metadata.CacheGetGroup(ctx, id)
+	return s.metadata.GetGroup(ctx, id)
 }
 
 // Get metadata of a feature group by name.
 func (s *OomStore) GetGroupByName(ctx context.Context, name string) (*types.Group, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	return s.metadata.CacheGetGroupByName(ctx, name)
+	return s.metadata.GetGroupByName(ctx, name)
 }
 
 // List metadata of feature groups under the same entity.
-func (s *OomStore) ListGroup(ctx context.Context, entityID *int) types.GroupList {
-	_ = s.metadata.Refresh()
-	return s.metadata.CacheListGroup(ctx, entityID)
+func (s *OomStore) ListGroup(ctx context.Context, entityID *int) (types.GroupList, error) {
+	return s.metadata.ListGroup(ctx, entityID)
 }
 
 // Update metadata of a feature group.
 func (s *OomStore) UpdateGroup(ctx context.Context, opt types.UpdateGroupOpt) error {
-	if err := s.metadata.Refresh(); err != nil {
-		return fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	group, err := s.metadata.CacheGetGroupByName(ctx, opt.GroupName)
+	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return err
 	}

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -17,7 +17,7 @@ func (s *OomStore) ChannelImport(ctx context.Context, opt types.ChannelImport) (
 	if err := s.metadata.Refresh(); err != nil {
 		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
 	}
-	group, err := s.metadata.CacheGetGroupByName(ctx, opt.GroupName)
+	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/oomstore/import_test.go
+++ b/pkg/oomstore/import_test.go
@@ -36,7 +36,7 @@ func TestChannelImportWithDependencyError(t *testing.T) {
 				GroupName: "device_info",
 			},
 			mockFunc: func() {
-				metadataStore.EXPECT().CacheGetGroupByName(gomock.Any(), "device_info").Return(nil, fmt.Errorf("error"))
+				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(nil, fmt.Errorf("error"))
 			},
 			wantRevisionID: 0,
 			wantError:      fmt.Errorf("error"),
@@ -47,7 +47,7 @@ func TestChannelImportWithDependencyError(t *testing.T) {
 				GroupName: "device_info",
 			},
 			mockFunc: func() {
-				metadataStore.EXPECT().CacheGetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1}, nil)
+				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1}, nil)
 				metadataStore.EXPECT().CacheListFeature(gomock.Any(), metadata.ListFeatureOpt{GroupID: intPtr(1)}).Return(nil)
 			},
 			wantRevisionID: 0,
@@ -59,7 +59,7 @@ func TestChannelImportWithDependencyError(t *testing.T) {
 				GroupName: "device_info",
 			},
 			mockFunc: func() {
-				metadataStore.EXPECT().CacheGetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1, EntityID: 1}, nil)
+				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1, EntityID: 1}, nil)
 				metadataStore.EXPECT().CacheListFeature(gomock.Any(), gomock.Any()).Return(types.FeatureList{})
 			},
 			wantRevisionID: 0,
@@ -79,7 +79,7 @@ device,model,price
 				GroupName: "device_info",
 			},
 			mockFunc: func() {
-				metadataStore.EXPECT().CacheGetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1, EntityID: 1, Entity: &types.Entity{Name: "device"}}, nil)
+				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1, EntityID: 1, Entity: &types.Entity{Name: "device"}}, nil)
 				metadataStore.EXPECT().CacheListFeature(gomock.Any(), metadata.ListFeatureOpt{GroupID: intPtr(1)}).
 					Return(types.FeatureList{
 						{
@@ -211,7 +211,7 @@ device,model,price
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
-			metadataStore.EXPECT().CacheGetGroupByName(ctx, tc.opt.GroupName).Return(&types.Group{
+			metadataStore.EXPECT().GetGroupByName(ctx, tc.opt.GroupName).Return(&types.Group{
 				ID:       1,
 				Name:     tc.opt.GroupName,
 				EntityID: tc.entityID,

--- a/pkg/oomstore/sync_test.go
+++ b/pkg/oomstore/sync_test.go
@@ -67,7 +67,7 @@ func TestSync(t *testing.T) {
 			mockFn: func() {
 				revision := buildRevision()
 				metadataStore.EXPECT().CacheGetRevision(ctx, 1).Return(revision, nil)
-				metadataStore.EXPECT().CacheGetGroupByName(ctx, "device_info").Return(&types.Group{
+				metadataStore.EXPECT().GetGroupByName(ctx, "device_info").Return(&types.Group{
 					Name: "device_info",
 					ID:   1,
 				}, nil)
@@ -102,7 +102,7 @@ func TestSync(t *testing.T) {
 				revision := buildRevision()
 				revision.Group.OnlineRevisionID = intPtr(0)
 				metadataStore.EXPECT().CacheGetRevision(ctx, 1).Return(revision, nil)
-				metadataStore.EXPECT().CacheGetGroupByName(ctx, "device_info").Return(&types.Group{
+				metadataStore.EXPECT().GetGroupByName(ctx, "device_info").Return(&types.Group{
 					Name: "device_info",
 					ID:   1,
 				}, nil)


### PR DESCRIPTION
This PR does:
- replace `CacheGetGroup`, `CacheGetGroupByName`, `CacheListGroup` by db-based methods
- delete group's informer-based methods

related to #661 