### PR TITLE
Jinghan/implement db-based revision methods

### DIFF
--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -290,6 +290,36 @@ func (mr *MockStoreMockRecorder) GetGroupByName(ctx, name interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupByName", reflect.TypeOf((*MockStore)(nil).GetGroupByName), ctx, name)
 }
 
+// GetRevision mocks base method.
+func (m *MockStore) GetRevision(ctx context.Context, id int) (*types.Revision, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRevision", ctx, id)
+	ret0, _ := ret[0].(*types.Revision)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRevision indicates an expected call of GetRevision.
+func (mr *MockStoreMockRecorder) GetRevision(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevision", reflect.TypeOf((*MockStore)(nil).GetRevision), ctx, id)
+}
+
+// GetRevisionBy mocks base method.
+func (m *MockStore) GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRevisionBy", ctx, groupID, revision)
+	ret0, _ := ret[0].(*types.Revision)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRevisionBy indicates an expected call of GetRevisionBy.
+func (mr *MockStoreMockRecorder) GetRevisionBy(ctx, groupID, revision interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevisionBy", reflect.TypeOf((*MockStore)(nil).GetRevisionBy), ctx, groupID, revision)
+}
+
 // ListEntity mocks base method.
 func (m *MockStore) ListEntity(ctx context.Context, entityIDs *[]int) (types.EntityList, error) {
 	m.ctrl.T.Helper()
@@ -306,18 +336,33 @@ func (mr *MockStoreMockRecorder) ListEntity(ctx, entityIDs interface{}) *gomock.
 }
 
 // ListGroup mocks base method.
-func (m *MockStore) ListGroup(ctx context.Context, entityID *int) (types.GroupList, error) {
+func (m *MockStore) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListGroup", ctx, entityID)
+	ret := m.ctrl.Call(m, "ListGroup", ctx, entityID, groupIDs)
 	ret0, _ := ret[0].(types.GroupList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListGroup indicates an expected call of ListGroup.
-func (mr *MockStoreMockRecorder) ListGroup(ctx, entityID interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) ListGroup(ctx, entityID, groupIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockStore)(nil).ListGroup), ctx, entityID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockStore)(nil).ListGroup), ctx, entityID, groupIDs)
+}
+
+// ListRevision mocks base method.
+func (m *MockStore) ListRevision(ctx context.Context, groupID *int) (types.RevisionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRevision", ctx, groupID)
+	ret0, _ := ret[0].(types.RevisionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRevision indicates an expected call of ListRevision.
+func (mr *MockStoreMockRecorder) ListRevision(ctx, groupID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRevision", reflect.TypeOf((*MockStore)(nil).ListRevision), ctx, groupID)
 }
 
 // Refresh mocks base method.
@@ -605,6 +650,36 @@ func (mr *MockReadStoreMockRecorder) GetGroupByName(ctx, name interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupByName", reflect.TypeOf((*MockReadStore)(nil).GetGroupByName), ctx, name)
 }
 
+// GetRevision mocks base method.
+func (m *MockReadStore) GetRevision(ctx context.Context, id int) (*types.Revision, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRevision", ctx, id)
+	ret0, _ := ret[0].(*types.Revision)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRevision indicates an expected call of GetRevision.
+func (mr *MockReadStoreMockRecorder) GetRevision(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevision", reflect.TypeOf((*MockReadStore)(nil).GetRevision), ctx, id)
+}
+
+// GetRevisionBy mocks base method.
+func (m *MockReadStore) GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRevisionBy", ctx, groupID, revision)
+	ret0, _ := ret[0].(*types.Revision)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRevisionBy indicates an expected call of GetRevisionBy.
+func (mr *MockReadStoreMockRecorder) GetRevisionBy(ctx, groupID, revision interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevisionBy", reflect.TypeOf((*MockReadStore)(nil).GetRevisionBy), ctx, groupID, revision)
+}
+
 // ListEntity mocks base method.
 func (m *MockReadStore) ListEntity(ctx context.Context, entityIDs *[]int) (types.EntityList, error) {
 	m.ctrl.T.Helper()
@@ -621,18 +696,33 @@ func (mr *MockReadStoreMockRecorder) ListEntity(ctx, entityIDs interface{}) *gom
 }
 
 // ListGroup mocks base method.
-func (m *MockReadStore) ListGroup(ctx context.Context, entityID *int) (types.GroupList, error) {
+func (m *MockReadStore) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListGroup", ctx, entityID)
+	ret := m.ctrl.Call(m, "ListGroup", ctx, entityID, groupIDs)
 	ret0, _ := ret[0].(types.GroupList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListGroup indicates an expected call of ListGroup.
-func (mr *MockReadStoreMockRecorder) ListGroup(ctx, entityID interface{}) *gomock.Call {
+func (mr *MockReadStoreMockRecorder) ListGroup(ctx, entityID, groupIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockReadStore)(nil).ListGroup), ctx, entityID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockReadStore)(nil).ListGroup), ctx, entityID, groupIDs)
+}
+
+// ListRevision mocks base method.
+func (m *MockReadStore) ListRevision(ctx context.Context, groupID *int) (types.RevisionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRevision", ctx, groupID)
+	ret0, _ := ret[0].(types.RevisionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRevision indicates an expected call of ListRevision.
+func (mr *MockReadStoreMockRecorder) ListRevision(ctx, groupID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRevision", reflect.TypeOf((*MockReadStore)(nil).ListRevision), ctx, groupID)
 }
 
 // Refresh mocks base method.

--- a/internal/database/metadata/postgres/db.go
+++ b/internal/database/metadata/postgres/db.go
@@ -43,8 +43,8 @@ func (db *DB) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return getGroupByName(ctx, db, name)
 }
 
-func (db *DB) ListGroup(ctx context.Context, entityID *int) (types.GroupList, error) {
-	return listGroup(ctx, db, entityID)
+func (db *DB) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
+	return listGroup(ctx, db, entityID, groupIDs)
 }
 
 func (db *DB) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) (int, error) {
@@ -78,4 +78,14 @@ func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt
 
 func (db *DB) UpdateRevision(ctx context.Context, opt metadata.UpdateRevisionOpt) error {
 	return updateRevision(ctx, db, opt)
+}
+
+func (db *DB) GetRevision(ctx context.Context, id int) (*types.Revision, error) {
+	return getRevision(ctx, db, id)
+}
+func (db *DB) GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error) {
+	return getRevisionBy(ctx, db, groupID, revision)
+}
+func (db *DB) ListRevision(ctx context.Context, groupID *int) (types.RevisionList, error) {
+	return listRevision(ctx, db, groupID)
 }

--- a/internal/database/metadata/postgres/revision.go
+++ b/internal/database/metadata/postgres/revision.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/lib/pq"
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
 func createRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateRevisionOpt) (int, string, error) {
@@ -76,6 +79,77 @@ func updateRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metad
 	}
 	if rowsAffected != 1 {
 		return fmt.Errorf("failed to update revision %d: revision not found", opt.RevisionID)
+	}
+	return nil
+}
+
+func getRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, id int) (*types.Revision, error) {
+	var revision types.Revision
+	query := `SELECT * FROM "feature_group_revision" WHERE id = $1`
+	if err := sqlxCtx.GetContext(ctx, &revision, query, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errdefs.NotFound(fmt.Errorf("revision %d not found", id))
+		}
+		return nil, err
+	}
+
+	group, err := getGroup(ctx, sqlxCtx, revision.GroupID)
+	if err != nil {
+		return nil, err
+	}
+	revision.Group = group
+	return &revision, nil
+}
+
+func getRevisionBy(ctx context.Context, sqlxCtx metadata.SqlxContext, groupID int, revision int64) (*types.Revision, error) {
+	var r types.Revision
+	query := `SELECT * FROM "feature_group_revision" WHERE "group_id" = $1 AND "revision" = $2`
+	if err := sqlxCtx.GetContext(ctx, &r, query, groupID, revision); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errdefs.NotFound(fmt.Errorf("revision not found by group %d and revision %d", groupID, revision))
+		}
+		return nil, err
+	}
+
+	group, err := getGroup(ctx, sqlxCtx, r.GroupID)
+	if err != nil {
+		return nil, err
+	}
+	r.Group = group
+	return &r, nil
+}
+func listRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, groupID *int) (types.RevisionList, error) {
+	query := `SELECT * FROM "feature_group_revision"`
+	args := make([]interface{}, 0)
+	if groupID != nil {
+		query = fmt.Sprintf(`%s WHERE group_id = $1`, query)
+		args = append(args, *groupID)
+	}
+	var revisions types.RevisionList
+	if err := sqlxCtx.SelectContext(ctx, &revisions, query, args...); err != nil {
+		return nil, err
+	}
+
+	if err := enrichRevisions(ctx, sqlxCtx, revisions); err != nil {
+		return nil, err
+	}
+	return revisions, nil
+}
+
+func enrichRevisions(ctx context.Context, sqlxCtx metadata.SqlxContext, revisions types.RevisionList) error {
+	groupIDs := revisions.GroupIDs()
+	groups, err := listGroup(ctx, sqlxCtx, nil, &groupIDs)
+	if err != nil {
+		return err
+	}
+	for _, revision := range revisions {
+		group := groups.Find(func(g *types.Group) bool {
+			return revision.GroupID == g.ID
+		})
+		if group == nil {
+			return fmt.Errorf("cannot find group %d for revision %d", revision.GroupID, revision.ID)
+		}
+		revision.Group = group
 	}
 	return nil
 }

--- a/internal/database/metadata/postgres/revision_test.go
+++ b/internal/database/metadata/postgres/revision_test.go
@@ -14,6 +14,18 @@ func TestUpdateRevision(t *testing.T) {
 	test_impl.TestUpdateRevision(t, prepareStore)
 }
 
+func TestCacheGetRevision(t *testing.T) {
+	test_impl.TestCacheGetRevision(t, prepareStore)
+}
+
+func TestCacheGetRevisionBy(t *testing.T) {
+	test_impl.TestCacheGetRevisionBy(t, prepareStore)
+}
+
+func TestCacheListRevision(t *testing.T) {
+	test_impl.TestCacheListRevision(t, prepareStore)
+}
+
 func TestGetRevision(t *testing.T) {
 	test_impl.TestGetRevision(t, prepareStore)
 }

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -28,7 +28,7 @@ type ReadStore interface {
 
 	GetGroup(ctx context.Context, id int) (*types.Group, error)
 	GetGroupByName(ctx context.Context, name string) (*types.Group, error)
-	ListGroup(ctx context.Context, entityID *int) (types.GroupList, error)
+	ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error)
 
 	CacheGetRevision(ctx context.Context, id int) (*types.Revision, error)
 	CacheGetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error)

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -34,6 +34,10 @@ type ReadStore interface {
 	CacheGetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error)
 	CacheListRevision(ctx context.Context, groupID *int) types.RevisionList
 
+	GetRevision(ctx context.Context, id int) (*types.Revision, error)
+	GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error)
+	ListRevision(ctx context.Context, groupID *int) (types.RevisionList, error)
+
 	// refresh
 	Refresh() error
 }

--- a/internal/database/metadata/test_impl/group.go
+++ b/internal/database/metadata/test_impl/group.go
@@ -91,21 +91,30 @@ func TestListGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	_, err = store.CreateGroup(ctx, userBehaviorOpt)
 	require.NoError(t, err)
 
-	groups, err := store.ListGroup(ctx, &deviceGroupID)
+	groups, err := store.ListGroup(ctx, &deviceGroupID, nil)
 	assert.NoError(t, err)
-	require.Equal(t, 1, len(groups))
+	assert.Equal(t, 1, len(groups))
 
-	groups, err = store.ListGroup(ctx, &userGroupID)
+	groups, err = store.ListGroup(ctx, &userGroupID, nil)
 	assert.NoError(t, err)
-	require.Equal(t, 2, len(groups))
+	assert.Equal(t, 2, len(groups))
 
-	groups, err = store.ListGroup(ctx, nil)
+	groups, err = store.ListGroup(ctx, nil, nil)
 	assert.NoError(t, err)
-	require.Equal(t, 3, len(groups))
+	assert.Equal(t, 3, len(groups))
 
-	groups, err = store.ListGroup(ctx, intPtr(0))
+	groups, err = store.ListGroup(ctx, intPtr(0), nil)
 	assert.NoError(t, err)
-	require.Equal(t, 0, len(groups))
+	assert.Equal(t, 0, len(groups))
+
+	ids := []int{deviceGroupID, userGroupID}
+	groups, err = store.ListGroup(ctx, nil, &ids)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(groups))
+
+	groups, err = store.ListGroup(ctx, &userEntityID, &ids)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(groups))
 }
 
 func TestCreateGroup(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -35,7 +35,7 @@ func (s *OomStore) GetGroupByName(ctx context.Context, name string) (*types.Grou
 
 // List metadata of feature groups under the same entity.
 func (s *OomStore) ListGroup(ctx context.Context, entityID *int) (types.GroupList, error) {
-	return s.metadata.ListGroup(ctx, entityID)
+	return s.metadata.ListGroup(ctx, entityID, nil)
 }
 
 // Update metadata of a feature group.

--- a/pkg/oomstore/types/revision.go
+++ b/pkg/oomstore/types/revision.go
@@ -60,3 +60,15 @@ func (l RevisionList) Filter(filter func(*Revision) bool) (rs RevisionList) {
 	}
 	return
 }
+
+func (l RevisionList) GroupIDs() []int {
+	groupIDMap := make(map[int]struct{})
+	for _, r := range l {
+		groupIDMap[r.GroupID] = struct{}{}
+	}
+	groupIDs := make([]int, 0, len(groupIDMap))
+	for id := range groupIDMap {
+		groupIDs = append(groupIDs, id)
+	}
+	return groupIDs
+}


### PR DESCRIPTION
This PR implements db-based revision methods: `GetRevision`, `GetRevisionBy`, `ListRevision`.

related to #660 