### PR TITLE
Jinghan/replace informer-based feature methods

### DIFF
--- a/internal/database/metadata/informer/informer.go
+++ b/internal/database/metadata/informer/informer.go
@@ -2,13 +2,11 @@ package informer
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"sync/atomic"
 	"time"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
-	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -95,28 +93,6 @@ func (f *Informer) Cache() *Cache {
 	return f.cache.Load().(*Cache)
 }
 
-// Get
-func (f *Informer) CacheGetFeature(ctx context.Context, id int) (*types.Feature, error) {
-	if feature := f.Cache().Features.Find(func(f *types.Feature) bool {
-		return f.ID == id
-	}); feature == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("feature %d not found", id))
-	} else {
-		return feature.Copy(), nil
-	}
-}
-
-func (f *Informer) CacheGetFeatureByName(ctx context.Context, name string) (*types.Feature, error) {
-	if feature := f.Cache().Features.Find(func(f *types.Feature) bool {
-		return f.Name == name
-	}); feature == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("feature '%s' not found", name))
-	} else {
-		return feature.Copy(), nil
-	}
-}
-
-// List
 func (f *Informer) CacheListFeature(ctx context.Context, opt metadata.ListFeatureOpt) types.FeatureList {
 	return f.Cache().Features.List(opt).Copy()
 }

--- a/internal/database/metadata/informer/informer_test.go
+++ b/internal/database/metadata/informer/informer_test.go
@@ -50,49 +50,40 @@ func TestInformer(t *testing.T) {
 	ctx, informer := prepareInformer(t)
 	defer informer.Close()
 
-	feature, err := informer.CacheGetFeature(ctx, 1)
-	require.NoError(t, err)
+	entityID := 1
+	features := informer.CacheListFeature(ctx, metadata.ListFeatureOpt{
+		EntityID: &entityID,
+	})
+	require.Equal(t, 1, len(features))
+	feature := features[0]
 
-	require.Equal(t, 1, feature.ID)
-	require.Equal(t, "price", feature.Name)
-	require.Equal(t, 100, feature.GroupID)
+	assert.Equal(t, 1, feature.ID)
+	assert.Equal(t, "price", feature.Name)
+	assert.Equal(t, 100, feature.GroupID)
 
-	require.NotNil(t, feature.Group)
-	require.Equal(t, 100, feature.Group.ID)
-	require.Equal(t, 1, feature.Group.Entity.ID)
-	require.Equal(t, "entity", feature.Group.Entity.Name)
+	assert.NotNil(t, feature.Group)
+	assert.Equal(t, 100, feature.Group.ID)
+	assert.Equal(t, 1, feature.Group.Entity.ID)
+	assert.Equal(t, "entity", feature.Group.Entity.Name)
 }
 
-func TestInformerDeepCopyGet(t *testing.T) {
+func TestInformerDeepCopy(t *testing.T) {
 	ctx, informer := prepareInformer(t)
 	defer informer.Close()
 
-	feature, err := informer.CacheGetFeature(ctx, 1)
-	require.NoError(t, err)
-
+	entityID := 1
+	features := informer.CacheListFeature(ctx, metadata.ListFeatureOpt{
+		EntityID: &entityID,
+	})
+	require.Equal(t, 1, len(features))
 	// changing this entity should not change the internal state of the informer
-	feature.Name = "new_price"
+	features[0].Name = "new_price"
 
-	feature, err = informer.CacheGetFeature(ctx, 1)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, feature.ID)
-	assert.Equal(t, 100, feature.GroupID)
-	assert.Equal(t, "price", feature.Name)
-}
-
-func TestInformerDeepCopyList(t *testing.T) {
-	ctx, informer := prepareInformer(t)
-	defer informer.Close()
-
-	featureList := informer.CacheListFeature(ctx, metadata.ListFeatureOpt{})
-	require.Equal(t, 1, len(featureList))
-
-	// changing this entity should not change the internal state of the informer
-	featureList[0].Name = "new_price"
-
-	feature, err := informer.CacheGetFeature(ctx, 1)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, feature.ID)
-	assert.Equal(t, 100, feature.GroupID)
-	assert.Equal(t, "price", feature.Name)
+	features = informer.CacheListFeature(ctx, metadata.ListFeatureOpt{
+		EntityID: &entityID,
+	})
+	require.Equal(t, 1, len(features))
+	assert.Equal(t, 1, features[0].ID)
+	assert.Equal(t, 100, features[0].GroupID)
+	assert.Equal(t, "price", features[0].Name)
 }

--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -37,36 +37,6 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// CacheGetFeature mocks base method.
-func (m *MockStore) CacheGetFeature(ctx context.Context, id int) (*types.Feature, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetFeature", ctx, id)
-	ret0, _ := ret[0].(*types.Feature)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetFeature indicates an expected call of CacheGetFeature.
-func (mr *MockStoreMockRecorder) CacheGetFeature(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetFeature", reflect.TypeOf((*MockStore)(nil).CacheGetFeature), ctx, id)
-}
-
-// CacheGetFeatureByName mocks base method.
-func (m *MockStore) CacheGetFeatureByName(ctx context.Context, name string) (*types.Feature, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetFeatureByName", ctx, name)
-	ret0, _ := ret[0].(*types.Feature)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetFeatureByName indicates an expected call of CacheGetFeatureByName.
-func (mr *MockStoreMockRecorder) CacheGetFeatureByName(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetFeatureByName", reflect.TypeOf((*MockStore)(nil).CacheGetFeatureByName), ctx, name)
-}
-
 // CacheListFeature mocks base method.
 func (m *MockStore) CacheListFeature(ctx context.Context, opt metadata.ListFeatureOpt) types.FeatureList {
 	m.ctrl.T.Helper()
@@ -775,36 +745,6 @@ func NewMockCacheStore(ctrl *gomock.Controller) *MockCacheStore {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCacheStore) EXPECT() *MockCacheStoreMockRecorder {
 	return m.recorder
-}
-
-// CacheGetFeature mocks base method.
-func (m *MockCacheStore) CacheGetFeature(ctx context.Context, id int) (*types.Feature, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetFeature", ctx, id)
-	ret0, _ := ret[0].(*types.Feature)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetFeature indicates an expected call of CacheGetFeature.
-func (mr *MockCacheStoreMockRecorder) CacheGetFeature(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetFeature", reflect.TypeOf((*MockCacheStore)(nil).CacheGetFeature), ctx, id)
-}
-
-// CacheGetFeatureByName mocks base method.
-func (m *MockCacheStore) CacheGetFeatureByName(ctx context.Context, name string) (*types.Feature, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CacheGetFeatureByName", ctx, name)
-	ret0, _ := ret[0].(*types.Feature)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CacheGetFeatureByName indicates an expected call of CacheGetFeatureByName.
-func (mr *MockCacheStoreMockRecorder) CacheGetFeatureByName(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheGetFeatureByName", reflect.TypeOf((*MockCacheStore)(nil).CacheGetFeatureByName), ctx, name)
 }
 
 // CacheListFeature mocks base method.

--- a/internal/database/metadata/postgres/feature_test.go
+++ b/internal/database/metadata/postgres/feature_test.go
@@ -22,10 +22,6 @@ func TestCreateFeatureWithInvalidDataType(t *testing.T) {
 	test_impl.TestCreateFeatureWithInvalidDataType(t, prepareStore)
 }
 
-func TestCacheGetFeature(t *testing.T) {
-	test_impl.TestCacheGetFeature(t, prepareStore)
-}
-
 func TestGetFeature(t *testing.T) {
 	test_impl.TestGetFeature(t, prepareStore)
 }

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -49,8 +49,6 @@ type DBStore interface {
 }
 
 type CacheStore interface {
-	CacheGetFeature(ctx context.Context, id int) (*types.Feature, error)
-	CacheGetFeatureByName(ctx context.Context, name string) (*types.Feature, error)
 	CacheListFeature(ctx context.Context, opt ListFeatureOpt) types.FeatureList
 
 	Refresh() error

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -96,33 +96,6 @@ func TestCreateFeatureWithInvalidDataType(t *testing.T, prepareStore PrepareStor
 	require.Error(t, err)
 }
 
-func TestCacheGetFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
-	ctx, store := prepareStore(t)
-	defer store.Close()
-	_, groupID := prepareEntityAndGroup(t, ctx, store)
-
-	id, err := store.CreateFeature(ctx, metadata.CreateFeatureOpt{
-		FeatureName: "phone",
-		GroupID:     groupID,
-		DBValueType: "varchar(16)",
-		Description: "description",
-		ValueType:   "string",
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, store.Refresh())
-
-	_, err = store.CacheGetFeature(ctx, 0)
-	require.EqualError(t, err, "feature 0 not found")
-
-	feature, err := store.CacheGetFeature(ctx, id)
-	require.NoError(t, err)
-	require.Equal(t, "phone", feature.Name)
-	require.Equal(t, "device_info", feature.Group.Name)
-	require.Equal(t, "varchar(16)", feature.DBValueType)
-	require.Equal(t, "description", feature.Description)
-}
-
 func TestGetFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
@@ -273,6 +246,7 @@ func TestListFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(features))
 }
+
 func TestUpdateFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 	ctx, store := prepareStore(t)
 	defer store.Close()
@@ -300,7 +274,7 @@ func TestUpdateFeature(t *testing.T, prepareStore PrepareStoreRuntimeFunc) {
 
 	require.NoError(t, store.Refresh())
 
-	feature, err := store.CacheGetFeature(ctx, id)
+	feature, err := store.GetFeature(ctx, id)
 	require.NoError(t, err)
 	require.Equal(t, "phone", feature.Name)
 	require.Equal(t, "device_info", feature.Group.Name)

--- a/oomcli/test/test_join.sh
+++ b/oomcli/test/test_join.sh
@@ -23,11 +23,11 @@ EOF
 
 case='oomcli join historical-feature'
 expected="
-entity_key,unix_milli,model,price
+entity_key,unix_milli,price,model
 1,$t1,,
 2,$t1,,
-1,$t2,xiaomi-mix3,3999
-2,$t2,huawei-p40,5299
+1,$t2,3999,xiaomi-mix3
+2,$t2,5299,huawei-p40
 "
 actual=$(oomcli join \
     --feature model,price \
@@ -51,11 +51,11 @@ EOF
 
 case='oomcli join historical-feature with real-time feature values'
 expected="
-entity_key,unix_milli,value_1,value_2,model,price
+entity_key,unix_milli,value_1,value_2,price,model
 1,$t1,1,2,,
 2,$t1,3,4,,
-1,$t2,5,6,xiaomi-mix3,3999
-2,$t2,7,8,huawei-p40,5299
+1,$t2,5,6,3999,xiaomi-mix3
+2,$t2,7,8,5299,huawei-p40
 "
 
 actual=$(oomcli join \

--- a/pkg/oomstore/apply_test.go
+++ b/pkg/oomstore/apply_test.go
@@ -19,7 +19,7 @@ func TestBuildApplyStage(t *testing.T) {
 		wantErr   error
 	}{
 		{
-			description: "invalid yaml: msissng kind",
+			description: "invalid yaml: missing kind",
 			opt: apply.ApplyOpt{R: strings.NewReader(`
 # kind: Entity
 name: user

--- a/pkg/oomstore/export_test.go
+++ b/pkg/oomstore/export_test.go
@@ -101,7 +101,7 @@ func TestChannelExport(t *testing.T) {
 				Name: "device_info",
 				ID:   1,
 			}, nil)
-			metadataStore.EXPECT().CacheListFeature(gomock.Any(), gomock.Any()).Return(features)
+			metadataStore.EXPECT().ListFeature(gomock.Any(), gomock.Any()).Return(features, nil)
 
 			featureNames := tc.opt.FeatureNames
 			if len(featureNames) == 0 {

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -10,25 +10,16 @@ import (
 
 // Get metadata of a feature by ID.
 func (s *OomStore) GetFeature(ctx context.Context, id int) (*types.Feature, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	return s.metadata.CacheGetFeature(ctx, id)
+	return s.metadata.GetFeature(ctx, id)
 }
 
 // Get metadata of a feature by name.
 func (s *OomStore) GetFeatureByName(ctx context.Context, name string) (*types.Feature, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	return s.metadata.CacheGetFeatureByName(ctx, name)
+	return s.metadata.GetFeatureByName(ctx, name)
 }
 
 // List metadata of features meeting particular criteria.
 func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (types.FeatureList, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
 	metadataOpt := metadata.ListFeatureOpt{
 		FeatureNames: opt.FeatureNames,
 	}
@@ -46,15 +37,12 @@ func (s *OomStore) ListFeature(ctx context.Context, opt types.ListFeatureOpt) (t
 		}
 		metadataOpt.GroupID = &group.ID
 	}
-	return s.metadata.CacheListFeature(ctx, metadataOpt), nil
+	return s.metadata.ListFeature(ctx, metadataOpt)
 }
 
 // Update metadata of a feature.
 func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt) error {
-	if err := s.metadata.Refresh(); err != nil {
-		return fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	feature, err := s.metadata.CacheGetFeatureByName(ctx, opt.FeatureName)
+	feature, err := s.metadata.GetFeatureByName(ctx, opt.FeatureName)
 	if err != nil {
 		return err
 	}
@@ -66,9 +54,6 @@ func (s *OomStore) UpdateFeature(ctx context.Context, opt types.UpdateFeatureOpt
 
 // Create metadata of a batch feature.
 func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatureOpt) (int, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
 	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -14,17 +14,17 @@ import (
 // ChannelImport a CSV data source into the feature store as a new revision.
 // In the future we want to support more diverse data sources.
 func (s *OomStore) ChannelImport(ctx context.Context, opt types.ChannelImport) (int, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return 0, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
 	group, err := s.metadata.GetGroupByName(ctx, opt.GroupName)
 	if err != nil {
 		return 0, err
 	}
 
-	features := s.metadata.CacheListFeature(ctx, metadata.ListFeatureOpt{
+	features, err := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
 		GroupID: &group.ID,
 	})
+	if err != nil {
+		return 0, err
+	}
 	if features == nil {
 		return 0, fmt.Errorf("no features under group: %s", opt.GroupName)
 	}

--- a/pkg/oomstore/import_test.go
+++ b/pkg/oomstore/import_test.go
@@ -48,7 +48,7 @@ func TestChannelImportWithDependencyError(t *testing.T) {
 			},
 			mockFunc: func() {
 				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1}, nil)
-				metadataStore.EXPECT().CacheListFeature(gomock.Any(), metadata.ListFeatureOpt{GroupID: intPtr(1)}).Return(nil)
+				metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{GroupID: intPtr(1)}).Return(nil, nil)
 			},
 			wantRevisionID: 0,
 			wantError:      fmt.Errorf("no features under group: device_info"),
@@ -60,7 +60,7 @@ func TestChannelImportWithDependencyError(t *testing.T) {
 			},
 			mockFunc: func() {
 				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1, EntityID: 1}, nil)
-				metadataStore.EXPECT().CacheListFeature(gomock.Any(), gomock.Any()).Return(types.FeatureList{})
+				metadataStore.EXPECT().ListFeature(gomock.Any(), gomock.Any()).Return(types.FeatureList{}, nil)
 			},
 			wantRevisionID: 0,
 			wantError:      fmt.Errorf("no entity found by group: device_info"),
@@ -80,7 +80,7 @@ device,model,price
 			},
 			mockFunc: func() {
 				metadataStore.EXPECT().GetGroupByName(gomock.Any(), "device_info").Return(&types.Group{ID: 1, EntityID: 1, Entity: &types.Entity{Name: "device"}}, nil)
-				metadataStore.EXPECT().CacheListFeature(gomock.Any(), metadata.ListFeatureOpt{GroupID: intPtr(1)}).
+				metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{GroupID: intPtr(1)}).
 					Return(types.FeatureList{
 						{
 							Name: "model",
@@ -88,7 +88,7 @@ device,model,price
 						{
 							Name: "price",
 						},
-					})
+					}, nil)
 				offlineStore.EXPECT().Import(gomock.Any(), gomock.Any()).AnyTimes().Return(int64(1), nil)
 
 				metadataStore.EXPECT().CreateRevision(gomock.Any(), gomock.Any()).Return(0, "", fmt.Errorf("error"))
@@ -218,7 +218,7 @@ device,model,price
 				Entity:   &tc.Entity,
 			}, nil)
 
-			metadataStore.EXPECT().CacheListFeature(ctx, metadata.ListFeatureOpt{GroupID: intPtr(1)}).Return(tc.features)
+			metadataStore.EXPECT().ListFeature(ctx, metadata.ListFeatureOpt{GroupID: intPtr(1)}).Return(tc.features, nil)
 
 			metadataStore.EXPECT().CreateRevision(ctx, metadata.CreateRevisionOpt{
 				Revision:    0,

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -19,12 +19,12 @@ import (
 // Get point-in-time correct feature values for each entity row.
 // Currently, this API only supports batch features.
 func (s *OomStore) ChannelJoin(ctx context.Context, opt types.ChannelJoinOpt) (*types.JoinResult, error) {
-	if err := s.metadata.Refresh(); err != nil {
-		return nil, fmt.Errorf("failed to refresh informer, err=%+v", err)
-	}
-	features := s.metadata.CacheListFeature(ctx, metadata.ListFeatureOpt{
+	features, err := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
 		FeatureNames: &opt.FeatureNames,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	features = features.Filter(func(f *types.Feature) bool {
 		return f.Group.Category == types.BatchFeatureCategory

--- a/pkg/oomstore/join_test.go
+++ b/pkg/oomstore/join_test.go
@@ -111,7 +111,7 @@ func TestChannelJoin(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
-			metadataStore.EXPECT().CacheListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureNames: &tc.opt.FeatureNames}).Return(tc.features)
+			metadataStore.EXPECT().ListFeature(gomock.Any(), metadata.ListFeatureOpt{FeatureNames: &tc.opt.FeatureNames}).Return(tc.features, nil)
 			if tc.entity != nil {
 				for _, featureList := range tc.featureMap {
 					metadataStore.EXPECT().ListRevision(gomock.Any(), &featureList[0].GroupID).Return(revisions, nil).AnyTimes()

--- a/pkg/oomstore/sync_test.go
+++ b/pkg/oomstore/sync_test.go
@@ -71,7 +71,7 @@ func TestSync(t *testing.T) {
 					Name: "device_info",
 					ID:   1,
 				}, nil)
-				metadataStore.EXPECT().CacheListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.Group.ID}).Return(features)
+				metadataStore.EXPECT().ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.Group.ID}).Return(features, nil)
 
 				stream := make(chan types.ExportRecord)
 				offlineStore.EXPECT().Export(ctx, offline.ExportOpt{
@@ -106,7 +106,7 @@ func TestSync(t *testing.T) {
 					Name: "device_info",
 					ID:   1,
 				}, nil)
-				metadataStore.EXPECT().CacheListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.Group.ID}).Return(features)
+				metadataStore.EXPECT().ListFeature(ctx, metadata.ListFeatureOpt{GroupID: &revision.Group.ID}).Return(features, nil)
 
 				stream := make(chan types.ExportRecord)
 				offlineStore.EXPECT().Export(ctx, offline.ExportOpt{


### PR DESCRIPTION
This PR replaces informer-based feature methods by db-based, except `CacheListFeature`, which is used in online_query.

close #661 