### PR TITLE
Jinghan/add output format `Column` for sub command `get meta`

### DIFF
--- a/oomcli/cmd/get_meta.go
+++ b/oomcli/cmd/get_meta.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
+
+var getMetaOutput *string
 
 var getMetaCmd = &cobra.Command{
 	Use:   "meta",
@@ -9,4 +13,7 @@ var getMetaCmd = &cobra.Command{
 
 func init() {
 	getCmd.AddCommand(getMetaCmd)
+
+	flags := getMetaCmd.PersistentFlags()
+	getMetaOutput = flags.StringP("output", "o", Column, "output format [csv,ascii_table,column]")
 }

--- a/oomcli/cmd/get_meta_feature.go
+++ b/oomcli/cmd/get_meta_feature.go
@@ -42,7 +42,7 @@ var getMetaFeatureCmd = &cobra.Command{
 		}
 
 		// print features to stdout
-		if err := printFeatures(features, *getOutput); err != nil {
+		if err := printFeatures(features, *getMetaOutput); err != nil {
 			log.Fatalf("failed printing features, error %v\n", err)
 		}
 	},
@@ -61,7 +61,9 @@ func printFeatures(features types.FeatureList, output string) error {
 	case CSV:
 		return printFeaturesInCSV(features)
 	case ASCIITable:
-		return printFeaturesInASCIITable(features)
+		return printFeaturesInASCIITable(features, true)
+	case Column:
+		return printFeaturesInASCIITable(features, false)
 	default:
 		return fmt.Errorf("unsupported output format %s", output)
 	}
@@ -82,10 +84,22 @@ func printFeaturesInCSV(features types.FeatureList) error {
 	return nil
 }
 
-func printFeaturesInASCIITable(features types.FeatureList) error {
+func printFeaturesInASCIITable(features types.FeatureList, border bool) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(featureHeader())
 	table.SetAutoFormatHeaders(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+
+	if !border {
+		table.SetBorder(false)
+		table.SetHeaderLine(false)
+		table.SetNoWhiteSpace(true)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetTablePadding("  ")
+	}
 
 	for _, feature := range features {
 		table.Append(featureRecord(feature))

--- a/oomcli/cmd/util.go
+++ b/oomcli/cmd/util.go
@@ -11,6 +11,7 @@ import (
 const (
 	CSV        = "csv"
 	ASCIITable = "ascii_table"
+	Column     = "column"
 )
 
 func mustOpenOomStore(ctx context.Context, opt types.OomStoreConfig) *oomstore.OomStore {


### PR DESCRIPTION
This PR adds a new output format `Column`, which will be used as default format for sub command `get meta`.