### PR TITLE
Jinghan/support `Column` output format for get meta commands

### DIFF
--- a/oomcli/cmd/get_meta_entity.go
+++ b/oomcli/cmd/get_meta_entity.go
@@ -56,7 +56,9 @@ func printEntities(entities types.EntityList, output string, wide bool) error {
 	case CSV:
 		return printEntitiesInCSV(entities, wide)
 	case ASCIITable:
-		return printEntitiesInASCIITable(entities, wide)
+		return printEntitiesInASCIITable(entities, true, wide)
+	case Column:
+		return printEntitiesInASCIITable(entities, false, wide)
 	default:
 		return fmt.Errorf("unsupported output format %s", output)
 	}
@@ -77,10 +79,22 @@ func printEntitiesInCSV(entities types.EntityList, wide bool) error {
 	return nil
 }
 
-func printEntitiesInASCIITable(entities types.EntityList, wide bool) error {
+func printEntitiesInASCIITable(entities types.EntityList, border, wide bool) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(entityHeader(wide))
 	table.SetAutoFormatHeaders(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+
+	if !border {
+		table.SetBorder(false)
+		table.SetHeaderLine(false)
+		table.SetNoWhiteSpace(true)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetTablePadding("  ")
+	}
 
 	for _, entity := range entities {
 		table.Append(entityRecord(entity, wide))

--- a/oomcli/cmd/get_meta_feature.go
+++ b/oomcli/cmd/get_meta_feature.go
@@ -110,9 +110,9 @@ func printFeaturesInASCIITable(features types.FeatureList, border, wide bool) er
 
 func featureHeader(wide bool) []string {
 	if wide {
-		return []string{"NAME", "GROUP", "ENTITY", "CATEGORY", "DB-VALUE-TYPE", "VALUE-TYPE", "DESCRIPTION", "ONLINE-REVISION-ID", "CREATE-TIME", "MODIFY-TIME"}
+		return []string{"ID", "NAME", "GROUP", "ENTITY", "CATEGORY", "DB-VALUE-TYPE", "VALUE-TYPE", "DESCRIPTION", "ONLINE-REVISION-ID", "CREATE-TIME", "MODIFY-TIME"}
 	}
-	return []string{"NAME", "GROUP", "ENTITY", "CATEGORY", "VALUE-TYPE"}
+	return []string{"ID", "NAME", "GROUP", "ENTITY", "CATEGORY", "VALUE-TYPE", "DESCRIPTION"}
 }
 
 func featureRecord(f *types.Feature, wide bool) []string {
@@ -123,7 +123,11 @@ func featureRecord(f *types.Feature, wide bool) []string {
 	}
 
 	if wide {
-		return []string{f.Name, f.Group.Name, f.Entity().Name, f.Group.Category, f.DBValueType, f.ValueType, f.Description, onlineRevisionID, f.CreateTime.Format(time.RFC3339), f.ModifyTime.Format(time.RFC3339)}
+		return []string{strconv.Itoa(f.ID), f.Name, f.Group.Name, f.Entity().Name, f.Group.Category, f.DBValueType, f.ValueType, f.Description, onlineRevisionID, f.CreateTime.Format(time.RFC3339), f.ModifyTime.Format(time.RFC3339)}
 	}
-	return []string{f.Name, f.Group.Name, f.Entity().Name, f.Group.Category, f.ValueType}
+	desc := f.Description
+	if len(desc) > MaxDescriptionLen {
+		desc = fmt.Sprintf("%s...", desc[0:MaxDescriptionLen])
+	}
+	return []string{strconv.Itoa(f.ID), f.Name, f.Group.Name, f.Entity().Name, f.Group.Category, f.ValueType, desc}
 }

--- a/oomcli/cmd/get_meta_group.go
+++ b/oomcli/cmd/get_meta_group.go
@@ -76,7 +76,9 @@ func printGroups(groups []*types.Group, output string, wide bool) error {
 	case CSV:
 		return printGroupsInCSV(groups, wide)
 	case ASCIITable:
-		return printGroupsInASCIITable(groups, wide)
+		return printGroupsInASCIITable(groups, true, wide)
+	case Column:
+		return printGroupsInASCIITable(groups, false, wide)
 	default:
 		return fmt.Errorf("unsupported output format %s", output)
 	}
@@ -97,10 +99,22 @@ func printGroupsInCSV(groups types.GroupList, wide bool) error {
 	return nil
 }
 
-func printGroupsInASCIITable(groups types.GroupList, wide bool) error {
+func printGroupsInASCIITable(groups types.GroupList, border, wide bool) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(groupHeader(wide))
 	table.SetAutoFormatHeaders(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+
+	if !border {
+		table.SetBorder(false)
+		table.SetHeaderLine(false)
+		table.SetNoWhiteSpace(true)
+		table.SetCenterSeparator("")
+		table.SetColumnSeparator("")
+		table.SetRowSeparator("")
+		table.SetTablePadding("  ")
+	}
 
 	for _, group := range groups {
 		table.Append(groupRecord(group, wide))

--- a/oomcli/test/test_apply_entity.sh
+++ b/oomcli/test/test_apply_entity.sh
@@ -93,11 +93,11 @@ group_actual=$(oomcli get meta group -o csv --wide)
 filter() { cut -d ',' -f 1-4 <<<"$1"; }
 assert_eq "oomcli get meta group" "$(filter "$group_expected" | sort)" "$(filter "$group_actual" | sort)"
 
-feature_expected='NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE
-model,device,user,batch,string
-price,device,user,batch,int64
-age,user,user,batch,int64
-gender,user,user,batch,int64
+feature_expected='ID,NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE,DESCRIPTION
+1,model,device,user,batch,string,description
+2,price,device,user,batch,int64,description
+3,age,user,user,batch,int64,description
+4,gender,user,user,batch,int64,description
 '
 feature_actual=$(oomcli get meta feature -o csv)
 assert_eq "oomcli get meta feature" "$(sort <<< "$feature_expected")" "$(sort <<< "$feature_actual")"

--- a/oomcli/test/test_apply_feature.sh
+++ b/oomcli/test/test_apply_feature.sh
@@ -36,9 +36,9 @@ description: 'description'
 EOF
 
 oomcli apply -f "$TMPFILE"
-feature_expected='NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE
-model,device,user,batch,string
-price,device,user,batch,int64
+feature_expected='ID,NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE,DESCRIPTION
+1,model,device,user,batch,string,description
+2,price,device,user,batch,int64,description
 '
 feature_actual=$(oomcli get meta feature -o csv)
 assert_eq "oomcli get meta feature" "$(sort <<< "$feature_expected")" "$(sort <<< "$feature_actual")"

--- a/oomcli/test/test_apply_group.sh
+++ b/oomcli/test/test_apply_group.sh
@@ -74,10 +74,10 @@ group_actual=$(oomcli get meta group -o csv --wide)
 filter() { cut -d ',' -f 1-4 <<<"$1"; }
 assert_eq "oomcli get meta group" "$(filter "$group_expected" | sort)" "$(filter "$group_actual" | sort)"
 
-feature_expected='NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE
-model,device,user,batch,string
-price,device,user,batch,int64
-radio,device,user,batch,int64
+feature_expected='ID,NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE,DESCRIPTION
+1,model,device,user,batch,string,description
+2,price,device,user,batch,int64,description
+3,radio,device,user,batch,int64,description
 '
 feature_actual=$(oomcli get meta feature -o csv)
 assert_eq "oomcli get meta feature" "$(sort <<< "$feature_expected")" "$(sort <<< "$feature_actual")"

--- a/oomcli/test/test_get_meta_feature.sh
+++ b/oomcli/test/test_get_meta_feature.sh
@@ -7,26 +7,26 @@ register_features
 import_sample > /dev/null
 
 case='oomcli get meta features works'
-expected='NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
-model,phone,device,batch,varchar(32),string,model,<NULL>
-price,phone,device,batch,int,int64,price,<NULL>
+expected='ID,NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
+1,price,phone,device,batch,int,int64,price,<NULL>
+2,model,phone,device,batch,varchar(32),string,model,<NULL>
 '
 actual=$(oomcli get meta feature -o csv --wide)
-ignore_time() { cut -d ',' -f 1-8 <<<"$1"; }
+ignore_time() { cut -d ',' -f 1-9 <<<"$1"; }
 assert_eq "$case" "$(sort <<< "$expected")" "$(ignore_time "$actual" | sort)"
 
 case='oomcli get simplified meta features works'
-expected='NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE
-model,phone,device,batch,string
-price,phone,device,batch,int64
+expected='ID,NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE,DESCRIPTION
+1,price,phone,device,batch,int64,price
+2,model,phone,device,batch,string,model
 '
 actual=$(oomcli get meta feature -o csv)
 assert_eq "$case" "$(sort <<< "$expected")" "$(sort <<< "$actual")"
 
 case='oomcli get one meta feature works'
-expected='NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
-model,phone,device,batch,varchar(32),string,model,<NULL>
+expected='ID,NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
+2,model,phone,device,batch,varchar(32),string,model,<NULL>
 '
 actual=$(oomcli get meta feature model -o csv --wide)
-ignore_time() { cut -d ',' -f 1-8 <<<"$1"; }
+ignore_time() { cut -d ',' -f 1-9 <<<"$1"; }
 assert_eq "$case" "$(sort <<< "$expected")" "$(ignore_time "$actual" | sort)"

--- a/oomcli/test/test_update_feature.sh
+++ b/oomcli/test/test_update_feature.sh
@@ -9,9 +9,9 @@ import_sample > /dev/null
 case='oomcli update feature works'
 oomcli update feature price --description "new description"
 expected='
-NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
-price,phone,device,batch,int,int64,new description,<NULL>
+ID,NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
+1,price,phone,device,batch,int,int64,new description,<NULL>
 '
 actual=$(oomcli get meta feature price -o csv --wide)
-ignore_time() { cut -d ',' -f 1-8 <<<"$1"; }
+ignore_time() { cut -d ',' -f 1-9 <<<"$1"; }
 assert_eq "$case"  "$expected" "$(ignore_time "$actual")"


### PR DESCRIPTION
This PR does:
- support output format `Column` for `get meta entity` and `get meta group`
- add `ID` and `DESCRIPTION` for command `get meta feature`

```
oomcli get meta entity --wide
ID  NAME  LENGTH  DESCRIPTION  CREATE-TIME           MODIFY-TIME
1   user  8       user ID      2021-11-18T08:05:37Z  2021-11-18T08:05:37Z

oomcli get meta group --wide
ID  NAME               ENTITY  DESCRIPTION                  ONLINE-REVISION-ID  CREATE-TIME           MODIFY-TIME
1   account            user    user account info            3                   2021-11-16T07:35:15Z  2021-11-17T03:56:37Z
2   transaction_stats  user    user transaction statistics  4                   2021-11-16T07:35:18Z  2021-11-17T04:02:12Z
```