### PR TITLE
feat(oomctl): subcommand get meta feature add -o yaml option

### DIFF
--- a/oomcli/cmd/get_meta.go
+++ b/oomcli/cmd/get_meta.go
@@ -15,6 +15,6 @@ func init() {
 	getCmd.AddCommand(getMetaCmd)
 
 	flags := getMetaCmd.PersistentFlags()
-	getMetaOutput = flags.StringP("output", "o", Column, "output format [csv,ascii_table,column]")
+	getMetaOutput = flags.StringP("output", "o", Column, "output format [csv,ascii_table,column,yaml]")
 	getMetaWide = flags.BoolP("wide", "w", false, "show detailed information")
 }

--- a/oomcli/cmd/get_meta_feature.go
+++ b/oomcli/cmd/get_meta_feature.go
@@ -7,11 +7,15 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types/apply"
 )
 
 var getMetaFeatureOpt types.ListFeatureOpt
@@ -64,9 +68,31 @@ func printFeatures(features types.FeatureList, output string, wide bool) error {
 		return printFeaturesInASCIITable(features, true, wide)
 	case Column:
 		return printFeaturesInASCIITable(features, false, wide)
+	case YAML:
+		return printFeatureInYaml(features)
 	default:
 		return fmt.Errorf("unsupported output format %s", output)
 	}
+}
+
+func printFeatureInYaml(features types.FeatureList) error {
+	var (
+		out   []byte
+		err   error
+		items = apply.FromFeatureList(features)
+	)
+
+	if len(items.Items) > 1 {
+		if out, err = yaml.Marshal(items); err != nil {
+			return err
+		}
+	} else if len(items.Items) == 1 {
+		if out, err = yaml.Marshal(items.Items[0]); err != nil {
+			return err
+		}
+	}
+	fmt.Println(strings.Trim(string(out), "\n"))
+	return nil
 }
 
 func printFeaturesInCSV(features types.FeatureList, wide bool) error {

--- a/oomcli/cmd/util.go
+++ b/oomcli/cmd/util.go
@@ -12,6 +12,7 @@ const (
 	CSV        = "csv"
 	ASCIITable = "ascii_table"
 	Column     = "column"
+	YAML       = "yaml"
 )
 
 func mustOpenOomStore(ctx context.Context, opt types.OomStoreConfig) *oomstore.OomStore {

--- a/oomcli/test/test_get_meta_feature.sh
+++ b/oomcli/test/test_get_meta_feature.sh
@@ -30,3 +30,34 @@ model,phone,device,batch,varchar(32),string,model,<NULL>
 actual=$(oomcli get meta feature model -o csv --wide)
 ignore_time() { cut -d ',' -f 1-8 <<<"$1"; }
 assert_eq "$case" "$(sort <<< "$expected")" "$(ignore_time "$actual" | sort)"
+
+
+case='oomcli get meta feature: one feature'
+expected='
+kind: Feature
+name: model
+group-name: phone
+db-value-type: varchar(32)
+description: varchar(32)
+'
+
+actual=$(oomcli get meta feature model -o yaml)
+assert_eq "$case" "$expected" "$actual"
+
+case='oomcli get meta feature: multiple features'
+expected='
+items:
+    - kind: Feature
+      name: price
+      group-name: phone
+      db-value-type: int
+      description: int
+    - kind: Feature
+      name: model
+      group-name: phone
+      db-value-type: varchar(32)
+      description: varchar(32)
+'
+
+actual=$(oomcli get meta feature -o yaml)
+assert_eq "$case" "$expected" "$actual"

--- a/pkg/oomstore/types/apply/apply.go
+++ b/pkg/oomstore/types/apply/apply.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/oom-ai/oomstore/pkg/errdefs"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
 type ApplyOpt struct {
@@ -26,11 +27,11 @@ func NewApplyStage() *ApplyStage {
 }
 
 type Feature struct {
-	Kind        string `mapstructure:"kind"`
-	Name        string `mapstructure:"name"`
-	GroupName   string `mapstructure:"group-name"`
-	DBValueType string `mapstructure:"db-value-type"`
-	Description string `mapstructure:"description"`
+	Kind        string `mapstructure:"kind" yaml:"kind"`
+	Name        string `mapstructure:"name" yaml:"name"`
+	GroupName   string `mapstructure:"group-name" yaml:"group-name"`
+	DBValueType string `mapstructure:"db-value-type" yaml:"db-value-type"`
+	Description string `mapstructure:"description" yaml:"description"`
 }
 
 func (f *Feature) Validate() error {
@@ -41,6 +42,27 @@ func (f *Feature) Validate() error {
 		return errdefs.InvalidAttribute(fmt.Errorf("the db value type of feature should not be empty"))
 	}
 	return nil
+}
+
+type FeatureItems struct {
+	Items []Feature `mapstructure:"items" yaml:"items"`
+}
+
+func FromFeatureList(features types.FeatureList) FeatureItems {
+	items := FeatureItems{
+		Items: make([]Feature, 0, features.Len()),
+	}
+
+	for _, f := range features {
+		items.Items = append(items.Items, Feature{
+			Kind:        "Feature",
+			Name:        f.Name,
+			GroupName:   f.Group.Name,
+			DBValueType: f.DBValueType,
+			Description: f.DBValueType,
+		})
+	}
+	return items
 }
 
 type Group struct {


### PR DESCRIPTION
this PR is added `-o yaml` option for subcommand `get meta feature`. 

one feature:

```yaml
(base) ➜  oomcli git:(feat/feature_output_in_yaml) ✗ oomcli get meta feature state -o yaml
kind: Feature
name: state
group-name: account
db-value-type: varchar(32)
description: varchar(32)
(base) ➜  oomcli git:(feat/feature_output_in_yaml) ✗ 
```

multiple features:

```yaml
(base) ➜  oomcli git:(feat/feature_output_in_yaml) ✗ ./oomcli get meta feature -o yaml      
items:
    - kind: Feature
      name: state
      group-name: account
      db-value-type: varchar(32)
      description: varchar(32)
    - kind: Feature
      name: credit_score
      group-name: account
      db-value-type: int
      description: int
    - kind: Feature
      name: account_age_days
      group-name: account
      db-value-type: int
      description: int
(base) ➜  oomcli git:(feat/feature_output_in_yaml) ✗ 
```

relate #694 