### PR TITLE
feat/subcommand get meta group add -o yaml option

### DIFF
--- a/oomcli/test/test_get_meta_feature.sh
+++ b/oomcli/test/test_get_meta_feature.sh
@@ -10,6 +10,7 @@ case='oomcli get meta features works'
 expected='ID,NAME,GROUP,ENTITY,CATEGORY,DB-VALUE-TYPE,VALUE-TYPE,DESCRIPTION,ONLINE-REVISION-ID
 1,price,phone,device,batch,int,int64,price,<NULL>
 2,model,phone,device,batch,varchar(32),string,model,<NULL>
+3,age,student,user,batch,int,int64,age,<NULL>
 '
 actual=$(oomcli get meta feature -o csv --wide)
 ignore_time() { cut -d ',' -f 1-9 <<<"$1"; }
@@ -19,6 +20,7 @@ case='oomcli get simplified meta features works'
 expected='ID,NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE,DESCRIPTION
 1,price,phone,device,batch,int64,price
 2,model,phone,device,batch,string,model
+3,age,student,user,batch,int64,age
 '
 actual=$(oomcli get meta feature -o csv)
 assert_eq "$case" "$(sort <<< "$expected")" "$(sort <<< "$actual")"
@@ -38,7 +40,7 @@ kind: Feature
 name: model
 group-name: phone
 db-value-type: varchar(32)
-description: varchar(32)
+description: model
 '
 
 actual=$(oomcli get meta feature model -o yaml)
@@ -51,12 +53,17 @@ items:
       name: price
       group-name: phone
       db-value-type: int
-      description: int
+      description: price
     - kind: Feature
       name: model
       group-name: phone
       db-value-type: varchar(32)
-      description: varchar(32)
+      description: model
+    - kind: Feature
+      name: age
+      group-name: student
+      db-value-type: int
+      description: age
 '
 
 actual=$(oomcli get meta feature -o yaml)

--- a/oomcli/test/test_get_meta_group.sh
+++ b/oomcli/test/test_get_meta_group.sh
@@ -9,6 +9,7 @@ register_features
 case='oomcli get meta group works'
 expected='ID,NAME,ENTITY,DESCRIPTION,ONLINE-REVISION-ID,CREATE-TIME,MODIFY-TIME
 1,phone,device,phone,<NULL>,2021-11-30T07:51:03Z,2021-11-30T08:19:13Z
+2,student,user,student
 '
 actual=$(oomcli get meta group -o csv --wide)
 ignore_time() { cut -d ',' -f 1-4 <<<"$1"; }
@@ -17,6 +18,7 @@ assert_eq "$case" "$(ignore_time "$expected" | sort)" "$(ignore_time "$actual" |
 case='oomcli get simplified group works'
 expected='ID,NAME,ENTITY,DESCRIPTION
 1,phone,device,phone
+2,student,user,student
 '
 actual=$(oomcli get meta group -o csv)
 assert_eq "$case" "$(sort <<< "$expected")" "$(sort <<< "$actual")"
@@ -27,3 +29,50 @@ expected='ID,NAME,ENTITY,DESCRIPTION
 '
 actual=$(oomcli get meta group phone -o csv)
 assert_eq "$case" "$(sort <<< "$expected")" "$(sort <<< "$actual")"
+
+case='oomcli get meta group -o yaml: one group'
+expected='
+kind: Group
+name: phone
+entity-name: device
+category: batch
+description: phone
+features:
+    - name: price
+      db-value-type: int
+      description: price
+    - name: model
+      db-value-type: varchar(32)
+      description: model
+'
+
+actual=$(oomcli get meta group phone -o yaml)
+assert_eq "$case" "$expected" "$actual"
+
+case='oomcli get meta group -o yaml: multiple groups'
+expected='
+items:
+    - kind: Group
+      name: phone
+      entity-name: device
+      category: batch
+      description: phone
+      features:
+        - name: price
+          db-value-type: int
+          description: price
+        - name: model
+          db-value-type: varchar(32)
+          description: model
+    - kind: Group
+      name: student
+      entity-name: user
+      category: batch
+      description: student
+      features:
+        - name: age
+          db-value-type: int
+          description: age
+'
+actual=$(oomcli get meta group -o yaml)
+assert_eq "$case" "$expected" "$actual"

--- a/oomcli/test/util.sh
+++ b/oomcli/test/util.sh
@@ -49,10 +49,12 @@ register_features() {
     oomcli register entity device --length 32     --description "device"
     oomcli register entity user   --length 64     --description "user"
 
-    oomcli register group phone --entity device --description "phone"
+    oomcli register group phone    --entity device  --description "phone"
+    oomcli register group student  --entity user    --description "student"
 
-    oomcli register batch-feature price --group phone --db-value-type "int"         --description "price"
-    oomcli register batch-feature model --group phone --db-value-type "varchar(32)" --description "model"
+    oomcli register batch-feature price --group phone    --db-value-type "int"          --description "price"
+    oomcli register batch-feature model --group phone    --db-value-type "varchar(32)"  --description "model"
+    oomcli register batch-feature age   --group student  --db-value-type "int"          --description "age"
 }
 
 # import sample data

--- a/pkg/oomstore/types/apply/apply.go
+++ b/pkg/oomstore/types/apply/apply.go
@@ -27,9 +27,9 @@ func NewApplyStage() *ApplyStage {
 }
 
 type Feature struct {
-	Kind        string `mapstructure:"kind" yaml:"kind"`
+	Kind        string `mapstructure:"kind" yaml:"kind,omitempty"`
 	Name        string `mapstructure:"name" yaml:"name"`
-	GroupName   string `mapstructure:"group-name" yaml:"group-name"`
+	GroupName   string `mapstructure:"group-name" yaml:"group-name,omitempty"`
 	DBValueType string `mapstructure:"db-value-type" yaml:"db-value-type"`
 	Description string `mapstructure:"description" yaml:"description"`
 }
@@ -48,6 +48,13 @@ type FeatureItems struct {
 	Items []Feature `mapstructure:"items" yaml:"items"`
 }
 
+func (f FeatureItems) Walk(walkFunc func(Feature) Feature) (rs FeatureItems) {
+	for _, i := range f.Items {
+		rs.Items = append(rs.Items, walkFunc(i))
+	}
+	return
+}
+
 func FromFeatureList(features types.FeatureList) FeatureItems {
 	items := FeatureItems{
 		Items: make([]Feature, 0, features.Len()),
@@ -59,20 +66,49 @@ func FromFeatureList(features types.FeatureList) FeatureItems {
 			Name:        f.Name,
 			GroupName:   f.Group.Name,
 			DBValueType: f.DBValueType,
-			Description: f.DBValueType,
+			Description: f.Description,
 		})
 	}
 	return items
 }
 
 type Group struct {
-	Kind        string    `mapstructure:"kind"`
-	Group       string    `mapstructure:"group"`
-	Name        string    `mapstructure:"name"`
-	EntityName  string    `mapstructure:"entity-name"`
-	Category    string    `mapstructure:"category"`
-	Description string    `mapstructure:"description"`
-	Features    []Feature `mapstructure:"features"`
+	Kind        string    `mapstructure:"kind" yaml:"kind"`
+	Group       string    `mapstructure:"group" yaml:"group,omitempty"`
+	Name        string    `mapstructure:"name" yaml:"name,omitempty"`
+	EntityName  string    `mapstructure:"entity-name" yaml:"entity-name"`
+	Category    string    `mapstructure:"category" yaml:"category"`
+	Description string    `mapstructure:"description" yaml:"description"`
+	Features    []Feature `mapstructure:"features" yaml:"features"`
+}
+
+type GroupItems struct {
+	Items []Group `mapstructure:"item" yaml:"items"`
+}
+
+func FromGroupList(groups types.GroupList, features types.FeatureList) GroupItems {
+	items := GroupItems{
+		Items: make([]Group, 0, groups.Len()),
+	}
+
+	for _, group := range groups {
+		items.Items = append(items.Items, Group{
+			Kind:        "Group",
+			Name:        group.Name,
+			EntityName:  group.Entity.Name,
+			Category:    group.Category,
+			Description: group.Description,
+			Features: FromFeatureList(features.Filter(func(f *types.Feature) bool {
+				return f.Group.Name == group.Name
+			})).Walk(func(f Feature) Feature {
+				f.Kind = ""
+				f.GroupName = ""
+				return f
+			}).Items,
+		})
+	}
+
+	return items
 }
 
 func (g *Group) Validate() error {

--- a/pkg/oomstore/types/group.go
+++ b/pkg/oomstore/types/group.go
@@ -38,6 +38,10 @@ func (fg *Group) Copy() *Group {
 
 type GroupList []*Group
 
+func (l *GroupList) Len() int {
+	return len(*l)
+}
+
 func (l GroupList) Copy() GroupList {
 	if len(l) == 0 {
 		return nil


### PR DESCRIPTION
this PR is added -o yaml option for subcommand `get meta group`.

one group:

```yaml
(base) ➜  oomcli git:(feat/group_output_in_yaml) ✗ oomcli get meta group account -o yaml
kind: Group
name: account
entity-name: user
category: batch
description: user account info
features:
    - name: credit_score
      db-value-type: int
      description: ""
    - name: account_age_days
      db-value-type: int
      description: ""
    - name: has_2fa_installed
      db-value-type: bool
      description: ""
    - name: state
      db-value-type: varchar(32)
      description: description
```

multiple groups:

```yaml
(base) ➜  oomcli git:(feat/group_output_in_yaml) ✗ oomcli get meta group -o yaml        
items:
    - kind: Group
      name: account
      entity-name: user
      category: batch
      description: user account info
      features:
        - name: credit_score
          db-value-type: int
          description: ""
        - name: account_age_days
          db-value-type: int
          description: ""
        - name: has_2fa_installed
          db-value-type: bool
          description: ""
        - name: state
          db-value-type: varchar(32)
          description: description
    - kind: Group
      name: transaction_stats
      entity-name: user
      category: batch
      description: user transaction statistics
      features:
        - name: transaction_count_7d
          db-value-type: int
          description: ""
        - name: transaction_count_30d
          db-value-type: int
          description: ""
```

relate #694 