### PR TITLE
Jinghan/support mysql as metadata store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/go-redis/redis/v7 v7.4.1 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/internal/database/metadata/mysql/database.go
+++ b/internal/database/metadata/mysql/database.go
@@ -1,0 +1,136 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/oom-ai/oomstore/internal/database/dbutil"
+	"github.com/oom-ai/oomstore/internal/database/metadata/informer"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+)
+
+//var _ metadata.Store = &DB{}
+//var _ metadata.DBStore = &Tx{}
+
+type DB struct {
+	*sqlx.DB
+	*informer.Informer
+}
+
+type Tx struct {
+	*sqlx.Tx
+}
+
+func (db *DB) Ping(ctx context.Context) error {
+	return db.DB.PingContext(ctx)
+}
+
+func (db *DB) Close() error {
+	if err := db.Informer.Close(); err != nil {
+		return err
+	}
+	if err := db.DB.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Open(ctx context.Context, option *types.MySQLOpt) (*DB, error) {
+	db, err := OpenDB(option.Host, option.Port, option.User, option.Password, option.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: make the interval configurable
+	informer, err := informer.New(time.Second, func() (*informer.Cache, error) {
+		return list(ctx, db)
+	})
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &DB{
+		DB:       db,
+		Informer: informer,
+	}, nil
+}
+
+func OpenDB(host, port, user, password, database string) (*sqlx.DB, error) {
+	return sqlx.Open(
+		"mysql",
+		fmt.Sprintf("%s:%s@(%s:%s)/%s", user, password, host, port, database))
+}
+
+func CreateDatabase(ctx context.Context, opt types.MySQLOpt) (err error) {
+	defaultDB, err := OpenDB(opt.Host, opt.Port, opt.User, opt.Password, "")
+	if err != nil {
+		return
+	}
+	defer defaultDB.Close()
+
+	if _, err = defaultDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", opt.Database)); err != nil {
+		return
+	}
+
+	db, err := OpenDB(opt.Host, opt.Port, opt.User, opt.Password, opt.Database)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	return createMetaSchemas(ctx, db)
+}
+
+func createMetaSchemas(ctx context.Context, db *sqlx.DB) (err error) {
+	// Use transaction to guarantee the following operations be executed
+	// on the same connection: http://go-database-sql.org/modifying.html
+	return dbutil.WithTransaction(db, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// create meta tables
+		for _, schema := range META_TABLE_SCHEMAS {
+			if _, err = tx.ExecContext(ctx, schema); err != nil {
+				return fmt.Errorf("failed to create table, err=%+v", err)
+			}
+		}
+
+		// create foreign keys
+		for _, stmt := range META_TABLE_FOREIGN_KEYS {
+			if _, err = tx.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("failed to add foreign key, err=%+v", err)
+			}
+		}
+
+		// create meta views
+		for _, schema := range META_VIEW_SCHEMAS {
+			if _, err = tx.ExecContext(ctx, schema); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func list(ctx context.Context, db *sqlx.DB) (*informer.Cache, error) {
+	var cache *informer.Cache
+	err := dbutil.WithTransaction(db, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		entities := types.EntityList{}
+		if err := tx.SelectContext(ctx, &entities, `SELECT * FROM entity`); err != nil {
+			return err
+		}
+
+		features := types.FeatureList{}
+		if err := tx.SelectContext(ctx, &features, `SELECT * FROM feature`); err != nil {
+			return err
+		}
+
+		groups := types.GroupList{}
+		if err := tx.SelectContext(ctx, &groups, `SELECT * FROM feature_group`); err != nil {
+			return err
+		}
+
+		cache = informer.NewCache(entities, features, groups)
+		return nil
+	})
+	return cache, err
+}

--- a/internal/database/metadata/mysql/database_test.go
+++ b/internal/database/metadata/mysql/database_test.go
@@ -1,0 +1,73 @@
+package mysql_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/oom-ai/oomstore/internal/database/metadata/mysql"
+	"github.com/oom-ai/oomstore/internal/database/test/runtime_mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//func prepareStore(t *testing.T) (context.Context, *mysql.DB) {
+//	return prepareDB(t)
+//}
+
+func prepareDB(t *testing.T) (context.Context, *mysql.DB) {
+	ctx := context.Background()
+	opt := runtime_mysql.MySQLDbOpt
+	db, err := mysql.OpenDB(
+		opt.Host,
+		opt.Port,
+		opt.User,
+		opt.Password,
+		opt.Database,
+	)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "drop database if exists test")
+	require.NoError(t, err)
+	db.Close()
+
+	err = mysql.CreateDatabase(ctx, runtime_mysql.MySQLDbOpt)
+	require.NoError(t, err)
+
+	mysqlDB, err := mysql.Open(ctx, &runtime_mysql.MySQLDbOpt)
+	require.NoError(t, err)
+
+	return ctx, mysqlDB
+}
+
+func TestCreateDatabase(t *testing.T) {
+	ctx, store := prepareDB(t)
+	defer store.Close()
+
+	var tables []string
+	err := store.SelectContext(ctx, &tables,
+		`SELECT table_name
+			FROM information_schema.tables
+			WHERE table_schema = 'test'
+			ORDER BY table_name;`)
+	require.NoError(t, err)
+
+	var wantTables []string
+	for table := range mysql.META_TABLE_SCHEMAS {
+		wantTables = append(wantTables, table)
+	}
+	for table := range mysql.META_VIEW_SCHEMAS {
+		wantTables = append(wantTables, table)
+	}
+
+	sort.Slice(tables, func(i, j int) bool {
+		return tables[i] < tables[j]
+	})
+	sort.Slice(wantTables, func(i, j int) bool {
+		return wantTables[i] < wantTables[j]
+	})
+	assert.Equal(t, wantTables, tables)
+}
+
+//func TestPing(t *testing.T) {
+//	test_impl.TestPing(t, prepareStore)
+//}

--- a/internal/database/metadata/mysql/schema.go
+++ b/internal/database/metadata/mysql/schema.go
@@ -1,0 +1,72 @@
+package mysql
+
+var META_TABLE_SCHEMAS = map[string]string{
+	"feature": `
+		CREATE TABLE feature (
+			id				INT 			NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			name          	VARCHAR(32) 	NOT	NULL,
+			group_id      	INT         	NOT	NULL,
+			db_value_type 	VARCHAR(32) 	NOT	NULL COMMENT "database data type of feature value",
+			value_type    	VARCHAR(16) 	NOT	NULL COMMENT "data type of feature value",
+			description   	VARCHAR(128)	DEFAULT '',
+			create_time   	TIMESTAMP    	NOT	NULL DEFAULT CURRENT_TIMESTAMP,
+			modify_time   	TIMESTAMP    	NOT	NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			UNIQUE (name)
+		);
+		`,
+	"feature_group": `
+		CREATE TABLE feature_group (
+			id					INT 			NOT	NULL AUTO_INCREMENT PRIMARY KEY,
+			name               	VARCHAR(32) 	NOT	NULL,
+			category           	VARCHAR(16) 	NOT	NULL COMMENT "group category: batch, stream",
+			entity_id          	INT         	NOT	NULL,
+			online_revision_id 	INT         	DEFAULT NULL,
+			description        	VARCHAR(64) 	DEFAULT '',
+			create_time        	TIMESTAMP   	NOT	NULL DEFAULT CURRENT_TIMESTAMP,
+			modify_time			TIMESTAMP   	NOT	NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			UNIQUE (name)
+		);
+		`,
+	"entity": `
+		CREATE TABLE entity (
+			id				INT 			NOT	NULL AUTO_INCREMENT PRIMARY KEY,
+			name        	VARCHAR(32) 	NOT	NULL,
+			length      	SMALLINT    	NOT	NULL COMMENT "feature entity value max length",
+			description 	VARCHAR(64) 	DEFAULT '',
+			create_time 	TIMESTAMP   	NOT	NULL DEFAULT CURRENT_TIMESTAMP,
+			modify_time 	TIMESTAMP   	NOT	NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			UNIQUE (name)
+		);
+		`,
+	"feature_group_revision": `
+		CREATE TABLE feature_group_revision (
+			id				INT 		NOT	NULL AUTO_INCREMENT PRIMARY KEY,
+			group_id    	INT         NOT	NULL,
+			revision    	BIGINT      NOT	NULL COMMENT "group data point-in-time epoch seconds",
+			data_table  	VARCHAR(64) NOT	NULL COMMENT "feature data table name",
+			anchored    	BOOLEAN     NOT	NULL,
+			description 	VARCHAR(64) DEFAULT '',
+			create_time 	TIMESTAMP   NOT	NULL DEFAULT CURRENT_TIMESTAMP,
+			modify_time 	TIMESTAMP   NOT	NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			UNIQUE (group_id, revision)
+		);
+		`,
+}
+
+var META_TABLE_FOREIGN_KEYS = map[string]string{
+	"feature": `
+		ALTER TABLE feature
+		ADD FOREIGN KEY (group_id) REFERENCES feature_group(id)
+	`,
+	"feature_group": `
+		ALTER TABLE feature_group
+		ADD FOREIGN KEY (entity_id) REFERENCES entity(id),
+		ADD FOREIGN KEY (online_revision_id) REFERENCES feature_group_revision(id)
+	`,
+	"feature_group_revision": `
+		ALTER TABLE feature_group_revision
+		ADD FOREIGN KEY (group_id) REFERENCES feature_group(id)
+	`,
+}
+
+var META_VIEW_SCHEMAS = map[string]string{}

--- a/internal/database/test/runtime_mysql/mysql.go
+++ b/internal/database/test/runtime_mysql/mysql.go
@@ -1,0 +1,43 @@
+package runtime_mysql
+
+import (
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/mysql"
+)
+
+var MySQLDbOpt types.MySQLOpt
+
+func init() {
+	mysqlContainer, err := gnomock.Start(
+		mysql.Preset(
+			mysql.WithUser("test", "test"),
+			mysql.WithDatabase("test"),
+			mysql.WithVersion("8.0"),
+		),
+		gnomock.WithUseLocalImagesFirst(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	MySQLDbOpt = types.MySQLOpt{
+		Host:     mysqlContainer.Host,
+		Port:     strconv.Itoa(mysqlContainer.DefaultPort()),
+		User:     "test",
+		Password: "test",
+		Database: "test",
+	}
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT)
+		<-c
+
+		_ = gnomock.Stop(mysqlContainer)
+	}()
+}

--- a/pkg/oomstore/types/config.go
+++ b/pkg/oomstore/types/config.go
@@ -43,3 +43,11 @@ type PostgresOpt struct {
 	Password string `yaml:"password"`
 	Database string `yaml:"database"`
 }
+
+type MySQLOpt struct {
+	Host     string `yaml:"host"`
+	Port     string `yaml:"port"`
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+	Database string `yaml:"database"`
+}


### PR DESCRIPTION
This PR introduces mysql as metadata store:
- define mysql table schema
- create database and tables

TODO:
- add db methods for mysql store
- reuse methods from postgres store


related to #718 