### PR TITLE
refactor: change usages of WithTransaction

### DIFF
--- a/internal/database/metadata/postgres/db.go
+++ b/internal/database/metadata/postgres/db.go
@@ -74,8 +74,8 @@ func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt
 		dataTable  string
 		err        error
 	)
-	err = db.WithTransaction(ctx, func(c context.Context, s metadata.DBStore) error {
-		revisionID, dataTable, err = createRevision(ctx, db, opt)
+	err = db.WithTransaction(ctx, func(c context.Context, tx metadata.DBStore) error {
+		revisionID, dataTable, err = tx.CreateRevision(c, opt)
 		return err
 	})
 	return revisionID, dataTable, err

--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -23,7 +23,7 @@ func (s *OomStore) Apply(ctx context.Context, opt apply.ApplyOpt) error {
 	return s.metadata.WithTransaction(ctx, func(c context.Context, tx metadata.DBStore) error {
 		// apply entity
 		for _, entity := range stage.NewEntities {
-			if err := s.applyEntity(ctx, tx, entity); err != nil {
+			if err := s.applyEntity(c, tx, entity); err != nil {
 				return err
 			}
 		}
@@ -31,14 +31,14 @@ func (s *OomStore) Apply(ctx context.Context, opt apply.ApplyOpt) error {
 		// apply group
 		for _, group := range stage.NewGroups {
 			group.Category = types.BatchFeatureCategory
-			if err := s.applyGroup(ctx, tx, group); err != nil {
+			if err := s.applyGroup(c, tx, group); err != nil {
 				return err
 			}
 		}
 
 		// apply feature
 		for _, feature := range stage.NewFeatures {
-			if err := s.applyFeature(ctx, tx, feature); err != nil {
+			if err := s.applyFeature(c, tx, feature); err != nil {
 				return err
 			}
 		}

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -54,9 +54,9 @@ func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
 		return err
 	}
 
-	if err = s.metadata.WithTransaction(ctx, func(ctx context.Context, tx metadata.DBStore) error {
+	if err = s.metadata.WithTransaction(ctx, func(c context.Context, tx metadata.DBStore) error {
 		// Update the online revision id of the feature group upon sync success
-		if err := tx.UpdateGroup(ctx, metadata.UpdateGroupOpt{
+		if err := tx.UpdateGroup(c, metadata.UpdateGroupOpt{
 			GroupID:             group.ID,
 			NewOnlineRevisionID: &revision.ID,
 		}); err != nil {
@@ -66,7 +66,7 @@ func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
 			newRevision := time.Now().Unix()
 			newChored := true
 			// Update revision timestamp using current timestamp
-			if err = tx.UpdateRevision(ctx, metadata.UpdateRevisionOpt{
+			if err = tx.UpdateRevision(c, metadata.UpdateRevisionOpt{
 				RevisionID:  revision.ID,
 				NewRevision: &newRevision,
 				NewAnchored: &newChored,


### PR DESCRIPTION
This PR modifies usages of `db.WithTransaction`, avoid useless `WithTransaction`.