### PR TITLE
test: fix integration tests

### DIFF
--- a/oomagent/test/config.yaml
+++ b/oomagent/test/config.yaml
@@ -9,14 +9,14 @@ offline-store:
   postgres:
     host: 127.0.0.1
     port: 5432
-    user: postgres
-    password: postgres
+    user: test
+    password: test
     database: oomstore_test
 
 metadata-store:
   postgres:
     host: 127.0.0.1
     port: 5432
-    user: postgres
-    password: postgres
+    user: test
+    password: test
     database: oomstore_test

--- a/oomcli/test/config.yaml
+++ b/oomcli/test/config.yaml
@@ -9,14 +9,14 @@ offline-store:
   postgres:
     host: 127.0.0.1
     port: 5432
-    user: postgres
-    password: postgres
+    user: test
+    password: test
     database: oomstore_test
 
 metadata-store:
   postgres:
     host: 127.0.0.1
     port: 5432
-    user: postgres
-    password: postgres
+    user: test
+    password: test
     database: oomstore_test


### PR DESCRIPTION
We need to make sure to use the same user/password to share the same db instance amount integration tests and unit tests.