### PR TITLE
Jinghan/add helper PrepareEntityRowsTable for method `Join`

### DIFF
--- a/internal/database/dbutil/db_opt.go
+++ b/internal/database/dbutil/db_opt.go
@@ -1,0 +1,68 @@
+package dbutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cast"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/jmoiron/sqlx"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+)
+
+type DBOpt struct {
+	Backend types.BackendType
+
+	// Sqlx
+	SqlxDB *sqlx.DB
+
+	// BigQuery
+	BigQueryDB *bigquery.Client
+	DatasetID  *string
+}
+
+func (d *DBOpt) ExecContext(ctx context.Context, query string, args []interface{}) error {
+	switch d.Backend {
+	case types.BIGQUERY:
+		_, err := d.BigQueryDB.Query(query).Read(ctx)
+		return err
+	default:
+		_, err := d.SqlxDB.ExecContext(ctx, d.SqlxDB.Rebind(query), args...)
+		return err
+	}
+}
+
+func (d *DBOpt) BuildInsertQuery(tableName string, records []interface{}, columns []string) (string, []interface{}, error) {
+	if len(records) == 0 {
+		return "", nil, nil
+	}
+
+	var columnStr string
+	switch d.Backend {
+	case types.POSTGRES, types.SNOWFLAKE, types.REDSHIFT:
+		columnStr = Quote(`"`, columns...)
+		tableName = fmt.Sprintf(`"%s"`, tableName)
+	case types.MYSQL, types.SQLite, types.BIGQUERY:
+		columnStr = Quote("`", columns...)
+		tableName = fmt.Sprintf("`%s`", tableName)
+	}
+
+	switch d.Backend {
+	case types.BIGQUERY:
+		values := make([]string, 0, len(records))
+		for _, row := range records {
+			values = append(values, fmt.Sprintf("(%s)", strings.Join(cast.ToStringSlice(row), ",")))
+		}
+		return fmt.Sprintf(`INSERT INTO %s.%s (%s) VALUES %s`, *d.DatasetID, tableName, columnStr, strings.Join(values, ",")), nil, nil
+	default:
+		valueFlags := make([]string, 0, len(records))
+		for i := 0; i < len(records); i++ {
+			valueFlags = append(valueFlags, "(?)")
+		}
+		return sqlx.In(
+			fmt.Sprintf(`INSERT INTO %s (%s) VALUES %s`, tableName, columnStr, strings.Join(valueFlags, ",")),
+			records...)
+	}
+}

--- a/internal/database/dbutil/sql.go
+++ b/internal/database/dbutil/sql.go
@@ -91,7 +91,7 @@ func GetColumnFormat(backendType types.BackendType) (string, error) {
 	switch backendType {
 	case types.POSTGRES, types.SNOWFLAKE, types.REDSHIFT:
 		columnFormat = `"%s" %s`
-	case types.MYSQL, types.SQLite:
+	case types.MYSQL, types.SQLite, types.BIGQUERY:
 		columnFormat = "`%s` %s"
 	default:
 		return "", fmt.Errorf("unsupported backend type %s", backendType)
@@ -104,7 +104,7 @@ func QuoteFn(backendType types.BackendType) (func(...string) string, error) {
 	switch backendType {
 	case types.POSTGRES, types.SNOWFLAKE, types.REDSHIFT:
 		quote = `"`
-	case types.MYSQL, types.SQLite:
+	case types.MYSQL, types.SQLite, types.BIGQUERY:
 		quote = "`"
 	default:
 		return nil, fmt.Errorf("unsupported backend type %s", backendType)

--- a/internal/database/dbutil/sql.go
+++ b/internal/database/dbutil/sql.go
@@ -27,22 +27,23 @@ func BuildConditions(equal map[string]interface{}, in map[string]interface{}) ([
 	return cond, args, nil
 }
 
-func InsertRecordsToTable(db *sqlx.DB, ctx context.Context, tableName string, records []interface{}, columns []string, backendType types.BackendType) error {
-	query, args, err := buildQueryAndArgsForInsertRecords(tableName, records, columns, backendType)
+func InsertRecordsToTable(ctx context.Context, dbOpt DBOpt, tableName string, records []interface{}, columns []string) error {
+	query, args, err := dbOpt.BuildInsertQuery(tableName, records, columns)
 	if err != nil {
 		return err
 	}
 	if query == "" {
 		return nil
 	}
-	if _, err := db.ExecContext(ctx, db.Rebind(query), args...); err != nil {
-		return err
-	}
-	return nil
+
+	return dbOpt.ExecContext(ctx, query, args)
 }
 
 func InsertRecordsToTableTx(tx *sqlx.Tx, ctx context.Context, tableName string, records []interface{}, columns []string, backendType types.BackendType) error {
-	query, args, err := buildQueryAndArgsForInsertRecords(tableName, records, columns, backendType)
+	dbOpt := DBOpt{
+		Backend: backendType,
+	}
+	query, args, err := dbOpt.BuildInsertQuery(tableName, records, columns)
 	if err != nil {
 		return err
 	}
@@ -53,29 +54,6 @@ func InsertRecordsToTableTx(tx *sqlx.Tx, ctx context.Context, tableName string, 
 		return err
 	}
 	return nil
-}
-
-func buildQueryAndArgsForInsertRecords(tableName string, records []interface{}, columns []string, backendType types.BackendType) (string, []interface{}, error) {
-	if len(records) == 0 {
-		return "", nil, nil
-	}
-	valueFlags := make([]string, 0, len(records))
-	for i := 0; i < len(records); i++ {
-		valueFlags = append(valueFlags, "(?)")
-	}
-
-	var columnStr string
-	switch backendType {
-	case types.POSTGRES, types.SNOWFLAKE, types.REDSHIFT:
-		columnStr = Quote(`"`, columns...)
-		tableName = fmt.Sprintf(`"%s"`, tableName)
-	case types.MYSQL, types.SQLite:
-		columnStr = Quote("`", columns...)
-		tableName = fmt.Sprintf("`%s`", tableName)
-	}
-	return sqlx.In(
-		fmt.Sprintf(`INSERT INTO %s (%s) VALUES %s`, tableName, columnStr, strings.Join(valueFlags, ",")),
-		records...)
 }
 
 func Quote(quote string, fields ...string) string {

--- a/internal/database/offline/sqlutil/join.go
+++ b/internal/database/offline/sqlutil/join.go
@@ -20,7 +20,11 @@ func Join(ctx context.Context, db *sqlx.DB, opt offline.JoinOpt, backendType typ
 	if len(features) == 0 {
 		return nil, nil
 	}
-	entityRowsTableName, err := createAndImportTableEntityRows(ctx, db, opt.Entity, opt.EntityRows, opt.ValueNames, backendType)
+	dbOpt := dbutil.DBOpt{
+		Backend: backendType,
+		SqlxDB:  db,
+	}
+	entityRowsTableName, err := PrepareEntityRowsTable(ctx, dbOpt, opt.Entity, opt.EntityRows, opt.ValueNames)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR does:
- define `dbutil.DBOpt`, add method `ExecContext` and `BuildInsertQuery`
- add helper function `PrepareEntityRowsTable`
- reuse `PrepareEntityRowsTable` in `sqlutil.Join` and `bigquery.Join`.

related to #780