### PR TITLE
Improve Join: unify helper func `JoinOneGroup`

### DIFF
--- a/internal/database/dbutil/db_opt.go
+++ b/internal/database/dbutil/db_opt.go
@@ -26,6 +26,9 @@ type DBOpt struct {
 func (d *DBOpt) ExecContext(ctx context.Context, query string, args []interface{}) error {
 	switch d.Backend {
 	case types.BackendBigQuery:
+		for _, arg := range args {
+			query = strings.Replace(query, "?", cast.ToString(arg), 1)
+		}
 		_, err := d.BigQueryDB.Query(query).Read(ctx)
 		return err
 	default:

--- a/internal/database/dbutil/type_mapping.go
+++ b/internal/database/dbutil/type_mapping.go
@@ -115,14 +115,6 @@ var (
 		types.Time:    "timestamp",
 		types.Bytes:   "blob",
 	}
-	valueTypeToRedshiftType = map[types.ValueType]string{
-		types.STRING:  "text",
-		types.INT64:   "bigint",
-		types.FLOAT64: "double precision",
-		types.BOOL:    "boolean",
-		types.TIME:    "timestamp",
-		types.BYTES:   "varbyte",
-	}
 	valueTypeToBigQueryType = map[types.ValueType]string{
 		types.String:  "string",
 		types.Int64:   "bigint",

--- a/internal/database/dbutil/type_mapping.go
+++ b/internal/database/dbutil/type_mapping.go
@@ -25,6 +25,8 @@ func DBValueType(backend types.BackendType, valueType types.ValueType) (string, 
 		mp = valueTypeToDynamoDBType
 	case types.BackendRedshift:
 		mp = valueTypeToRedshiftType
+	case types.BackendBigQuery:
+		mp = valueTypeToBigQueryType
 	default:
 		return "", errdefs.InvalidAttribute(fmt.Errorf("unsupported backend: %s", backend))
 	}
@@ -121,6 +123,15 @@ var (
 		types.TIME:    "timestamp",
 		types.BYTES:   "varbyte",
 	}
+	valueTypeToBigQueryType = map[types.ValueType]string{
+		types.String:  "string",
+		types.Int64:   "bigint",
+		types.Float64: "float64",
+		types.Bool:    "bool",
+		types.Time:    "datetime",
+		types.Bytes:   "bytes",
+	}
+	valueTypeToRedshiftType = valueTypeToPostgresType
 )
 
 // Mapping database data type to feature value type


### PR DESCRIPTION
This PR unifies helper function `JoinOneGroup`, now it could be used by `bigquery.Join` and `sqlutil.Join`.

related to #780 