### PR TITLE
Improve Join: unify helper func ReadJoinedTable

### DIFF
--- a/internal/database/offline/bigquery/join.go
+++ b/internal/database/offline/bigquery/join.go
@@ -2,7 +2,6 @@ package bigquery
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oom-ai/oomstore/internal/database/offline/sqlutil"
 
@@ -58,81 +57,18 @@ func (db *DB) Join(ctx context.Context, opt offline.JoinOpt) (*types.JoinResult,
 	}
 
 	//// Step 3: read joined results
-	return readJoinedTable(ctx, db, entityRowsTableName, tableNames, tableToFeatureMap, opt.ValueNames, types.BackendMySQL)
+	return sqlutil.ReadJoinedTable(ctx, dbOpt, sqlutil.ReadJoinedTableOpt{
+		EntityRowsTableName: entityRowsTableName,
+		TableNames:          tableNames,
+		FeatureMap:          tableToFeatureMap,
+		ValueNames:          opt.ValueNames,
+		QueryResults:        bigqueryQueryResults,
+		ReadJoinResultQuery: READ_JOIN_RESULT_QUERY,
+	})
 }
 
-func readJoinedTable(
-	ctx context.Context,
-	db *DB,
-	entityRowsTableName string,
-	tableNames []string,
-	featureMap map[string]types.FeatureList,
-	valueNames []string,
-	backendType types.BackendType,
-) (*types.JoinResult, error) {
-	if len(tableNames) == 0 {
-		return nil, nil
-	}
-	qt, err := dbutil.QuoteFn(backendType)
-	if err != nil {
-		return nil, err
-	}
-	entityKeyStr := qt("entity_key")
-	unixMilliStr := qt("unix_milli")
-
-	// Step 1: join temporary tables
-	/*
-		SELECT
-		entity_rows_table.entity_key,
-			entity_rows_table.unix_milli,
-			joined_table_1.feature_1,
-			joined_table_1.feature_2,
-			joined_table_2.feature_3
-		FROM entity_rows_table
-		LEFT JOIN joined_table_1
-		ON entity_rows_table.entity_key = joined_table_1.entity_key AND entity_rows_table.unix_milli = joined_table_1.unix_milli
-		LEFT JOIN joined_table_2
-		ON entity_rows_table.entity_key = joined_table_2.entity_key AND entity_rows_table.unix_milli = joined_table_2.unix_milli;
-	*/
-	var (
-		header         []string
-		fields         []string
-		joinTablePairs []joinTablePair
-	)
-
-	header = append(header, "entity_key", "unix_milli")
-	for _, name := range valueNames {
-		fields = append(fields, qt(name))
-		header = append(header, name)
-	}
-	for _, name := range tableNames {
-		for _, f := range featureMap[name] {
-			fields = append(fields, fmt.Sprintf("%s.%s", qt(name), qt(f.Name)))
-			header = append(header, f.Name)
-		}
-	}
-
-	tableNames = append([]string{entityRowsTableName}, tableNames...)
-	for i := 0; i < len(tableNames)-1; i++ {
-		joinTablePairs = append(joinTablePairs, joinTablePair{
-			LeftTable:  tableNames[i],
-			RightTable: tableNames[i+1],
-		})
-	}
-	query, err := buildReadJoinResultQuery(readJoinResultQuery{
-		EntityRowsTableName: entityRowsTableName,
-		EntityKeyStr:        entityKeyStr,
-		UnixMilliStr:        unixMilliStr,
-		Fields:              fields,
-		JoinTables:          joinTablePairs,
-		Backend:             backendType,
-		DatasetID:           db.datasetID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	// Step 2: read joined results
-	rows, err := db.Query(query).Read(ctx)
+func bigqueryQueryResults(ctx context.Context, dbOpt dbutil.DBOpt, query string, header, tableNames []string) (*types.JoinResult, error) {
+	rows, err := dbOpt.BigQueryDB.Query(query).Read(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +78,7 @@ func readJoinedTable(
 
 	go func() {
 		defer func() {
-			if err := dropTemporaryTables(ctx, db, tableNames); err != nil {
+			if err = dropTemporaryTables(ctx, dbOpt.BigQueryDB, tableNames); err != nil {
 				dropErr = err
 			}
 			defer close(data)
@@ -168,13 +104,14 @@ func readJoinedTable(
 	if scanErr != nil {
 		return nil, scanErr
 	}
+
 	return &types.JoinResult{
 		Header: header,
 		Data:   data,
 	}, dropErr
 }
 
-func dropTemporaryTables(ctx context.Context, db *DB, tableNames []string) error {
+func dropTemporaryTables(ctx context.Context, db *bigquery.Client, tableNames []string) error {
 	var err error
 	for _, tableName := range tableNames {
 		if tmpErr := dropTable(ctx, db, tableName); tmpErr != nil {

--- a/internal/database/offline/bigquery/join_helper.go
+++ b/internal/database/offline/bigquery/join_helper.go
@@ -1,17 +1,13 @@
 package bigquery
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"strings"
-	"text/template"
 
-	"github.com/oom-ai/oomstore/internal/database/dbutil"
-	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+	"cloud.google.com/go/bigquery"
 )
 
-func dropTable(ctx context.Context, db *DB, tableName string) error {
+func dropTable(ctx context.Context, db *bigquery.Client, tableName string) error {
 	query := fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName)
 	_, err := db.Query(query).Read(ctx)
 	return err
@@ -29,37 +25,3 @@ FROM {{ $.DatasetID }}.{{ qt .EntityRowsTableName }}
 lEFT JOIN {{ $.DatasetID }}.{{ $t2 }}
 ON {{ $t1 }}.{{ $.UnixMilliStr }} = {{ $t2 }}.{{ $.UnixMilliStr }} AND {{ $t1 }}.{{ $.EntityKeyStr }} = {{ $t2 }}.{{ $.EntityKeyStr }}
 {{end}}`
-
-type joinTablePair struct {
-	LeftTable  string
-	RightTable string
-}
-
-type readJoinResultQuery struct {
-	EntityRowsTableName string
-	EntityKeyStr        string
-	UnixMilliStr        string
-	Fields              []string
-	JoinTables          []joinTablePair
-	Backend             types.BackendType
-	DatasetID           string
-}
-
-func buildReadJoinResultQuery(schema readJoinResultQuery) (string, error) {
-	qt, err := dbutil.QuoteFn(schema.Backend)
-	if err != nil {
-		return "", err
-	}
-	t := template.Must(template.New("temp_join").Funcs(template.FuncMap{
-		"qt": qt,
-		"fieldJoin": func(fields []string) string {
-			return strings.Join(fields, ",\n\t")
-		},
-	}).Parse(READ_JOIN_RESULT_QUERY))
-
-	buf := bytes.NewBuffer(nil)
-	if err := t.Execute(buf, schema); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}

--- a/internal/database/offline/sqlutil/join_helper.go
+++ b/internal/database/offline/sqlutil/join_helper.go
@@ -202,17 +202,18 @@ type joinTablePair struct {
 	RightTable string
 }
 
-type readJoinResultQuery struct {
+type readJoinResultQueryParams struct {
 	EntityRowsTableName string
 	EntityKeyStr        string
 	UnixMilliStr        string
 	Fields              []string
 	JoinTables          []joinTablePair
 	Backend             types.BackendType
+	DatasetID           string
 }
 
-func buildReadJoinResultQuery(schema readJoinResultQuery) (string, error) {
-	qt, err := dbutil.QuoteFn(schema.Backend)
+func buildReadJoinResultQuery(query string, params readJoinResultQueryParams) (string, error) {
+	qt, err := dbutil.QuoteFn(params.Backend)
 	if err != nil {
 		return "", err
 	}
@@ -221,10 +222,10 @@ func buildReadJoinResultQuery(schema readJoinResultQuery) (string, error) {
 		"fieldJoin": func(fields []string) string {
 			return strings.Join(fields, ",\n\t")
 		},
-	}).Parse(READ_JOIN_RESULT_QUERY))
+	}).Parse(query))
 
 	buf := bytes.NewBuffer(nil)
-	if err := t.Execute(buf, schema); err != nil {
+	if err := t.Execute(buf, params); err != nil {
 		return "", err
 	}
 	return buf.String(), nil


### PR DESCRIPTION
This PR unifies helper function `ReadJoinedTable`, now it is used in both `bigquery.Join` and `sqlutil.Join`.

related to #780 