### PR TITLE
refactor(tyeps): rename FeatureXXXCategory to Category

### DIFF
--- a/internal/database/metadata/mysql/group.go
+++ b/internal/database/metadata/mysql/group.go
@@ -10,7 +10,7 @@ import (
 )
 
 func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateGroupOpt) (int, error) {
-	if opt.Category != types.BatchFeatureCategory && opt.Category != types.StreamFeatureCategory {
+	if opt.Category != types.CategoryBatch && opt.Category != types.CategoryStream {
 		return 0, fmt.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category)
 	}
 

--- a/internal/database/metadata/postgres/group.go
+++ b/internal/database/metadata/postgres/group.go
@@ -11,7 +11,7 @@ import (
 )
 
 func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateGroupOpt) (int, error) {
-	if opt.Category != types.BatchFeatureCategory && opt.Category != types.StreamFeatureCategory {
+	if opt.Category != types.CategoryBatch && opt.Category != types.CategoryStream {
 		return 0, fmt.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category)
 	}
 	var groupID int

--- a/internal/database/metadata/sqlite/group.go
+++ b/internal/database/metadata/sqlite/group.go
@@ -10,7 +10,7 @@ import (
 )
 
 func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateGroupOpt) (int, error) {
-	if opt.Category != types.BatchFeatureCategory && opt.Category != types.StreamFeatureCategory {
+	if opt.Category != types.CategoryBatch && opt.Category != types.CategoryStream {
 		return 0, fmt.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category)
 	}
 

--- a/internal/database/metadata/test_impl/feature.go
+++ b/internal/database/metadata/test_impl/feature.go
@@ -27,7 +27,7 @@ func prepareEntityAndGroup(t *testing.T, ctx context.Context, store metadata.Sto
 		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	})
 	require.NoError(t, err)
 	require.NoError(t, store.Refresh())

--- a/internal/database/metadata/test_impl/group.go
+++ b/internal/database/metadata/test_impl/group.go
@@ -35,7 +35,7 @@ func TestGetGroup(t *testing.T, prepareStore PrepareStoreFn, destroyStore Destro
 		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	}
 	id, err := store.CreateGroup(ctx, opt)
 	require.NoError(t, err)
@@ -74,19 +74,19 @@ func TestListGroup(t *testing.T, prepareStore PrepareStoreFn, destroyStore Destr
 		GroupName:   "device_info",
 		EntityID:    deviceEntityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	}
 	userBaseOpt := metadata.CreateGroupOpt{
 		GroupName:   "user_info",
 		EntityID:    userEntityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	}
 	userBehaviorOpt := metadata.CreateGroupOpt{
 		GroupName:   "user_profile",
 		EntityID:    userEntityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	}
 	deviceGroupID, err := store.CreateGroup(ctx, deviceOpt)
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestCreateGroup(t *testing.T, prepareStore PrepareStoreFn, destroyStore Des
 		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	}
 
 	// create successfully
@@ -167,7 +167,7 @@ func TestUpdateGroup(t *testing.T, prepareStore PrepareStoreFn, destroyStore Des
 		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	}
 	groupID, err := store.CreateGroup(ctx, opt)
 	require.NoError(t, err)

--- a/internal/database/metadata/test_impl/revision.go
+++ b/internal/database/metadata/test_impl/revision.go
@@ -336,7 +336,7 @@ func prepareRevisions(t *testing.T, ctx context.Context, store metadata.Store) (
 		GroupName:   "device_info",
 		EntityID:    entityID,
 		Description: "description",
-		Category:    types.BatchFeatureCategory,
+		Category:    types.CategoryBatch,
 	})
 	require.NoError(t, err)
 	require.NoError(t, store.Refresh())

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -25,7 +25,7 @@ type CreateGroupOpt struct {
 	GroupName   string
 	EntityID    int
 	Description string
-	Category    string
+	Category    types.Category
 }
 
 type CreateRevisionOpt struct {

--- a/oomcli/cmd/types.go
+++ b/oomcli/cmd/types.go
@@ -33,7 +33,7 @@ type FlattenFeature struct {
 	Name        string          `oomcli:"NAME"`
 	Group       string          `oomcli:"GROUP"`
 	Entity      string          `oomcli:"ENTITY"`
-	Category    string          `oomcli:"CATEGORY"`
+	Category    types.Category  `oomcli:"CATEGORY"`
 	ValueType   types.ValueType `oomcli:"VALUE-TYPE"`
 	Description string          `oomcli:"DESCRIPTION,truncate"`
 

--- a/oomcli/test/test_apply_entity.sh
+++ b/oomcli/test/test_apply_entity.sh
@@ -55,7 +55,7 @@ ID,NAME,GROUP,ENTITY,CATEGORY,VALUE-TYPE,DESCRIPTION
 4,gender,user,user,batch,int64,description
 '
     feature_actual=$(oomcli get meta feature -o csv)
-    assert_eq "apply_single_complex_entity(: check feature" "$(sort <<< "$feature_expected")" "$(sort <<< "$feature_actual")"
+    assert_eq "apply_single_complex_entity: check feature" "$(sort <<< "$feature_expected")" "$(sort <<< "$feature_actual")"
 }
 
 apply_multiple_files_of_entity() {

--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -31,7 +31,7 @@ func (s *OomStore) Apply(ctx context.Context, opt apply.ApplyOpt) error {
 
 		// apply group
 		for _, group := range stage.NewGroups {
-			group.Category = types.BatchFeatureCategory
+			group.Category = types.CategoryBatch
 			if err := s.applyGroup(c, tx, group); err != nil {
 				return err
 			}
@@ -242,7 +242,7 @@ func buildApplyStage(ctx context.Context, opt apply.ApplyOpt) (*apply.ApplyStage
 
 					for _, group := range entity.BatchFeatures {
 						group.Name = group.Group
-						group.Category = types.BatchFeatureCategory
+						group.Category = types.CategoryBatch
 						stage.NewGroups = append(stage.NewGroups, buildApplyGroup(group, entity.Name))
 
 						for _, feature := range group.Features {

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -58,7 +58,7 @@ func (s *OomStore) CreateBatchFeature(ctx context.Context, opt types.CreateFeatu
 	if err != nil {
 		return 0, err
 	}
-	if group.Category != types.BatchFeatureCategory {
+	if group.Category != types.CategoryBatch {
 		return 0, fmt.Errorf("expected batch feature group, got %s feature group", group.Category)
 	}
 

--- a/pkg/oomstore/feature_test.go
+++ b/pkg/oomstore/feature_test.go
@@ -42,7 +42,7 @@ func TestCreateBatchFeature(t *testing.T) {
 			group: types.Group{
 				ID:       1,
 				Name:     "device_info",
-				Category: types.BatchFeatureCategory,
+				Category: types.CategoryBatch,
 			},
 			expectError: false,
 		},
@@ -57,7 +57,7 @@ func TestCreateBatchFeature(t *testing.T) {
 			group: types.Group{
 				ID:       1,
 				Name:     "device_info",
-				Category: types.StreamFeatureCategory,
+				Category: types.CategoryStream,
 			},
 			expectError: true,
 		},
@@ -68,7 +68,7 @@ func TestCreateBatchFeature(t *testing.T) {
 			metadataStore.EXPECT().Refresh().Return(nil).AnyTimes()
 			metadataStore.EXPECT().GetGroupByName(ctx, tc.opt.GroupName).Return(&tc.group, nil)
 
-			if tc.group.Category == types.BatchFeatureCategory {
+			if tc.group.Category == types.CategoryBatch {
 				metadataOpt := metadata.CreateFeatureOpt{
 					FeatureName: tc.opt.FeatureName,
 					FullName:    fmt.Sprintf("%s.%s", tc.opt.GroupName, tc.opt.FeatureName),

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -19,7 +19,7 @@ func (s *OomStore) CreateGroup(ctx context.Context, opt types.CreateGroupOpt) (i
 		Description: opt.Description,
 		// Via the oomstore API, we can only create a batch feature group
 		// So we hardcode the category to be batch
-		Category: types.BatchFeatureCategory,
+		Category: types.CategoryBatch,
 	})
 }
 

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -27,7 +27,7 @@ func (s *OomStore) ChannelJoin(ctx context.Context, opt types.ChannelJoinOpt) (*
 	}
 
 	features = features.Filter(func(f *types.Feature) bool {
-		return f.Group.Category == types.BatchFeatureCategory
+		return f.Group.Category == types.CategoryBatch
 	})
 	if len(features) == 0 {
 		return nil, nil

--- a/pkg/oomstore/online_query_test.go
+++ b/pkg/oomstore/online_query_test.go
@@ -222,7 +222,7 @@ func prepareFeatures(isConsistent bool, isAvailable bool) types.FeatureList {
 			Group: &types.Group{
 				EntityID:         1,
 				OnlineRevisionID: &revision1,
-				Category:         types.BatchFeatureCategory,
+				Category:         types.CategoryBatch,
 				Entity:           entityDevice,
 			},
 		},
@@ -233,7 +233,7 @@ func prepareFeatures(isConsistent bool, isAvailable bool) types.FeatureList {
 			Group: &types.Group{
 				EntityID:         1,
 				OnlineRevisionID: &revision2,
-				Category:         types.BatchFeatureCategory,
+				Category:         types.CategoryBatch,
 				Entity:           entityDevice,
 			},
 		},
@@ -244,7 +244,7 @@ func prepareFeatures(isConsistent bool, isAvailable bool) types.FeatureList {
 			Group: &types.Group{
 				EntityID:         2,
 				OnlineRevisionID: &revision2,
-				Category:         types.BatchFeatureCategory,
+				Category:         types.CategoryBatch,
 				Entity:           entityUser,
 			},
 		},
@@ -252,7 +252,7 @@ func prepareFeatures(isConsistent bool, isAvailable bool) types.FeatureList {
 	if !isAvailable {
 		for i := range features {
 			features[i].Group.OnlineRevisionID = nil
-			features[i].Group.Category = types.StreamFeatureCategory
+			features[i].Group.Category = types.CategoryStream
 		}
 	}
 

--- a/pkg/oomstore/types/apply/apply.go
+++ b/pkg/oomstore/types/apply/apply.go
@@ -73,13 +73,13 @@ func FromFeatureList(features types.FeatureList) FeatureItems {
 }
 
 type Group struct {
-	Kind        string    `mapstructure:"kind" yaml:"kind,omitempty"`
-	Group       string    `mapstructure:"group" yaml:"group,omitempty"`
-	Name        string    `mapstructure:"name" yaml:"name,omitempty"`
-	EntityName  string    `mapstructure:"entity-name" yaml:"entity-name,omitempty"`
-	Category    string    `mapstructure:"category" yaml:"category,omitempty"`
-	Description string    `mapstructure:"description" yaml:"description"`
-	Features    []Feature `mapstructure:"features" yaml:"features,omitempty"`
+	Kind        string         `mapstructure:"kind" yaml:"kind,omitempty"`
+	Group       string         `mapstructure:"group" yaml:"group,omitempty"`
+	Name        string         `mapstructure:"name" yaml:"name,omitempty"`
+	EntityName  string         `mapstructure:"entity-name" yaml:"entity-name,omitempty"`
+	Category    types.Category `mapstructure:"category" yaml:"category,omitempty"`
+	Description string         `mapstructure:"description" yaml:"description"`
+	Features    []Feature      `mapstructure:"features" yaml:"features,omitempty"`
 }
 
 type GroupItems struct {

--- a/pkg/oomstore/types/group.go
+++ b/pkg/oomstore/types/group.go
@@ -5,9 +5,9 @@ import (
 )
 
 type Group struct {
-	ID       int    `db:"id"`
-	Name     string `db:"name"`
-	Category string `db:"category"`
+	ID       int      `db:"id"`
+	Name     string   `db:"name"`
+	Category Category `db:"category"`
 
 	Description string    `db:"description"`
 	CreateTime  time.Time `db:"create_time"`

--- a/pkg/oomstore/types/types.go
+++ b/pkg/oomstore/types/types.go
@@ -1,9 +1,16 @@
 package types
 
+type Category string
+
 const (
-	BatchFeatureCategory  = "batch"
-	StreamFeatureCategory = "stream"
+	CategoryBatch  Category = "batch"
+	CategoryStream Category = "stream"
 )
+
+// In order for cast.ToString to correctly resolve Category, Category needs to implement the interface String
+func (c Category) String() string {
+	return string(c)
+}
 
 type ExportRecord []interface{}
 


### PR DESCRIPTION
since the group also have two kinds (Batch or Stream), so this PR does:
1. rename `FeatureBatchCategory` and `FeatureStreamCategory` to `BatchCategory` and `StreamCategory`
2. define enum type `types.Category`

relate #820 