### PR TITLE
`List` method: order by id

### DIFF
--- a/internal/database/metadata/sqlutil/feature.go
+++ b/internal/database/metadata/sqlutil/feature.go
@@ -92,6 +92,7 @@ func ListFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata
 	if len(cond) > 0 {
 		query = fmt.Sprintf("%s WHERE %s", query, strings.Join(cond, " AND "))
 	}
+	query = fmt.Sprintf("%s ORDER BY id ASC", query)
 	if err := sqlxCtx.SelectContext(ctx, &features, sqlxCtx.Rebind(query), args...); err != nil {
 		return nil, err
 	}

--- a/internal/database/metadata/sqlutil/group.go
+++ b/internal/database/metadata/sqlutil/group.go
@@ -92,6 +92,7 @@ func ListGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, entityID *int,
 	if len(cond) > 0 {
 		query = fmt.Sprintf("%s WHERE %s", query, cond)
 	}
+	query = fmt.Sprintf("%s ORDER BY id ASC", query)
 	var groups types.GroupList
 	if err := sqlxCtx.SelectContext(ctx, &groups, sqlxCtx.Rebind(query), args...); err != nil {
 		return nil, err

--- a/internal/database/metadata/sqlutil/revision.go
+++ b/internal/database/metadata/sqlutil/revision.go
@@ -89,6 +89,7 @@ func ListRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, groupID *in
 		query = fmt.Sprintf(`%s WHERE group_id = ?`, query)
 		args = append(args, *groupID)
 	}
+	query = fmt.Sprintf("%s ORDER BY id ASC", query)
 	var revisions types.RevisionList
 	if err := sqlxCtx.SelectContext(ctx, &revisions, sqlxCtx.Rebind(query), args...); err != nil {
 		return nil, err

--- a/oomagent/test/test_channel_import.sh
+++ b/oomagent/test/test_channel_import.sh
@@ -24,9 +24,9 @@ assert_json_eq "$case" "$expected" "$actual"
 
 case="data actually imported"
 expected='
-user,state,credit_score,account_age_days,has_2fa_installed
+user,account.state,account.credit_score,account.account_age_days,account.has_2fa_installed
 10,Idaho,693,212,true
 '
 oomcli sync -r 3
-actual=$(oomcli get online --feature state,credit_score,account_age_days,has_2fa_installed -k 10 -o csv)
+actual=$(oomcli get online --feature account.state,account.credit_score,account.account_age_days,account.has_2fa_installed -k 10 -o csv)
 assert_eq "$case" "$expected" "$actual"

--- a/oomagent/test/test_channel_join.sh
+++ b/oomagent/test/test_channel_join.sh
@@ -15,9 +15,9 @@ case1="api returns correct result"
 arg1='
 {
   "feature_names": [
-    "conv_rate",
-    "acc_rate",
-    "avg_daily_trips"
+    "driver_stats.conv_rate",
+    "driver_stats.acc_rate",
+    "driver_stats.avg_daily_trips"
   ],
   "entity_row": {
     "entity_key": "1",
@@ -31,9 +31,9 @@ expected1='
   "header": [
     "entity_key",
     "unix_milli",
-    "conv_rate",
-    "acc_rate",
-    "avg_daily_trips"
+    "driver_stats.conv_rate",
+    "driver_stats.acc_rate",
+    "driver_stats.avg_daily_trips"
   ],
   "joinedRow": [
     {

--- a/oomagent/test/test_import_from_file.sh
+++ b/oomagent/test/test_import_from_file.sh
@@ -25,9 +25,9 @@ assert_json_eq "$case" "$expected" "$actual"
 
 case="data actually imported"
 expected='
-user,state,credit_score,account_age_days,has_2fa_installed
+user,account.state,account.credit_score,account.account_age_days,account.has_2fa_installed
 10,Idaho,693,212,true
 '
 oomcli sync -r 3
-actual=$(oomcli get online --feature state,credit_score,account_age_days,has_2fa_installed -k 10 -o csv)
+actual=$(oomcli get online --feature account.state,account.credit_score,account.account_age_days,account.has_2fa_installed -k 10 -o csv)
 assert_eq "$case" "$expected" "$actual"

--- a/oomagent/test/test_join_using_file.sh
+++ b/oomagent/test/test_join_using_file.sh
@@ -21,9 +21,9 @@ case="api returns ok"
 arg=$(cat <<-EOF
 {
   "feature_names": [
-    "conv_rate",
-    "acc_rate",
-    "avg_daily_trips"
+    "driver_stats.conv_rate",
+    "driver_stats.acc_rate",
+    "driver_stats.avg_daily_trips"
   ],
   "input_file_path": "./data/driver_stats_label.csv",
   "output_file_path": "$output"
@@ -40,7 +40,7 @@ assert_json_eq "$case" "$expected" "$actual"
 
 case="result is correct"
 expected='
-entity_key,unix_milli,conv_rate,acc_rate,avg_daily_trips
+entity_key,unix_milli,driver_stats.conv_rate,driver_stats.acc_rate,driver_stats.avg_daily_trips
 1,0,,,
 1,3,0.556,0.465,464
 1,4,0.377,0.991,329

--- a/oomagent/test/test_online_get.sh
+++ b/oomagent/test/test_online_get.sh
@@ -9,7 +9,7 @@ case="query single feature"
 arg='
 {
     "entity_key": "19",
-    "feature_names": ["state"]
+    "feature_names": ["account.state"]
 }
 '
 expected='
@@ -19,7 +19,7 @@ expected='
   },
   "result": {
     "map": {
-      "state": {
+      "account.state": {
         "stringValue": "Illinois"
       }
     }
@@ -33,7 +33,7 @@ case="query multiple features"
 arg='
 {
     "entity_key": "48",
-    "feature_names": ["state", "credit_score", "transaction_count_7d", "transaction_count_30d"]
+    "feature_names": ["account.state", "account.credit_score", "transaction_stats.transaction_count_7d", "transaction_stats.transaction_count_30d"]
 }
 '
 expected='
@@ -41,16 +41,16 @@ expected='
   "status": {},
   "result": {
     "map": {
-      "credit_score": {
+      "account.credit_score": {
         "int64Value": "708"
       },
-      "state": {
+      "account.state": {
         "stringValue": "Indiana"
       },
-      "transaction_count_30d": {
+      "transaction_stats.transaction_count_30d": {
         "int64Value": "45"
       },
-      "transaction_count_7d": {
+      "transaction_stats.transaction_count_7d": {
         "int64Value": "5"
       }
     }

--- a/oomagent/test/test_online_multi_get.sh
+++ b/oomagent/test/test_online_multi_get.sh
@@ -9,7 +9,7 @@ case="query single feature"
 arg='
 {
     "entity_keys": ["19", "50", "78"],
-    "feature_names": ["state"]
+    "feature_names": ["account.state"]
 }
 '
 expected='
@@ -18,21 +18,21 @@ expected='
   "result": {
     "19": {
       "map": {
-        "state": {
+        "account.state": {
           "stringValue": "Illinois"
         }
       }
     },
     "50": {
       "map": {
-        "state": {
+        "account.state": {
           "stringValue": "Hawaii"
         }
       }
     },
     "78": {
       "map": {
-        "state": {
+        "account.state": {
           "stringValue": "Tennessee"
         }
       }
@@ -47,7 +47,7 @@ case="query multiple features"
 arg='
 {
     "entity_keys": ["48", "74"],
-    "feature_names": ["state", "credit_score", "transaction_count_7d", "transaction_count_30d"]
+    "feature_names": ["account.state", "account.credit_score", "transaction_stats.transaction_count_7d", "transaction_stats.transaction_count_30d"]
 }
 '
 expected='
@@ -56,32 +56,32 @@ expected='
   "result": {
     "48": {
       "map": {
-        "credit_score": {
+        "account.credit_score": {
           "int64Value": "708"
         },
-        "state": {
+        "account.state": {
           "stringValue": "Indiana"
         },
-        "transaction_count_30d": {
+        "transaction_stats.transaction_count_30d": {
           "int64Value": "45"
         },
-        "transaction_count_7d": {
+        "transaction_stats.transaction_count_7d": {
           "int64Value": "5"
         }
       }
     },
     "74": {
       "map": {
-        "credit_score": {
+        "account.credit_score": {
           "int64Value": "703"
         },
-        "state": {
+        "account.state": {
           "stringValue": "Ohio"
         },
-        "transaction_count_30d": {
+        "transaction_stats.transaction_count_30d": {
           "int64Value": "25"
         },
-        "transaction_count_7d": {
+        "transaction_stats.transaction_count_7d": {
           "int64Value": "8"
         }
       }


### PR DESCRIPTION
This PR refactors all `List` methods (except `CacheListFeature`): order output objects by id.

close #830 