### PR TITLE
Jinghan/update revision's  `snapshot_table`

### DIFF
--- a/internal/database/metadata/sqlutil/revision.go
+++ b/internal/database/metadata/sqlutil/revision.go
@@ -22,6 +22,9 @@ func UpdateRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metad
 	if opt.NewAnchored != nil {
 		and["anchored"] = *opt.NewAnchored
 	}
+	if opt.NewSnapshotTable != nil {
+		and["snapshot_table"] = *opt.NewSnapshotTable
+	}
 	cond, args, err := dbutil.BuildConditions(and, nil)
 	if err != nil {
 		return err

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -48,9 +48,10 @@ type UpdateGroupOpt struct {
 }
 
 type UpdateRevisionOpt struct {
-	RevisionID  int
-	NewRevision *int64
-	NewAnchored *bool
+	RevisionID       int
+	NewRevision      *int64
+	NewAnchored      *bool
+	NewSnapshotTable *string
 }
 
 type ListFeatureOpt struct {


### PR DESCRIPTION
This PR modifies metadata method `UpdateRevision`: able to update `snapshot_table`.

This feature will be used for creating snapshot tables for streaming features.


related to #805 
