### PR TITLE
fix: add missing backend to switch

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -17,6 +17,7 @@ import (
 	offlinePG "github.com/oom-ai/oomstore/internal/database/offline/postgres"
 	offlineRedshift "github.com/oom-ai/oomstore/internal/database/offline/redshift"
 	offlineSnowflake "github.com/oom-ai/oomstore/internal/database/offline/snowflake"
+	offlineSQLite "github.com/oom-ai/oomstore/internal/database/offline/sqlite"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 	onlineCassandra "github.com/oom-ai/oomstore/internal/database/online/cassandra"
@@ -24,6 +25,8 @@ import (
 	onlineMySQL "github.com/oom-ai/oomstore/internal/database/online/mysql"
 	onlinePG "github.com/oom-ai/oomstore/internal/database/online/postgres"
 	onlineRedis "github.com/oom-ai/oomstore/internal/database/online/redis"
+	onlineSQLite "github.com/oom-ai/oomstore/internal/database/online/sqlite"
+	onlineTiKV "github.com/oom-ai/oomstore/internal/database/online/tikv"
 )
 
 func OpenOnlineStore(opt types.OnlineStoreConfig) (online.Store, error) {
@@ -38,6 +41,10 @@ func OpenOnlineStore(opt types.OnlineStoreConfig) (online.Store, error) {
 		return onlineDynamoDB.Open(opt.DynamoDB)
 	case types.BackendCassandra:
 		return onlineCassandra.Open(opt.Cassandra)
+	case types.BackendSQLite:
+		return onlineSQLite.Open(opt.SQLite)
+	case types.BackendTiKV:
+		return onlineTiKV.Open(opt.TiKV)
 	default:
 		return nil, fmt.Errorf("unsupported backend: %s", opt.Backend)
 	}
@@ -81,6 +88,8 @@ func OpenOfflineStore(ctx context.Context, opt types.OfflineStoreConfig) (offlin
 		return offlineBigQuery.Open(ctx, opt.BigQuery)
 	case types.BackendRedshift:
 		return offlineRedshift.Open(opt.Redshift)
+	case types.BackendSQLite:
+		return offlineSQLite.Open(opt.SQLite)
 	default:
 		return nil, fmt.Errorf("unsupported backend: %s", opt.Backend)
 	}

--- a/pkg/oomstore/types/config.go
+++ b/pkg/oomstore/types/config.go
@@ -33,7 +33,9 @@ type OnlineStoreConfig struct {
 	MySQL     *MySQLOpt     `yaml:"mysql"`
 	DynamoDB  *DynamoDBOpt  `yaml:"dynamodb"`
 	Cassandra *CassandraOpt `yaml:"cassandra"`
+	SQLite    *SQLiteOpt    `yaml:"sqlite"`
 	TiDB      *MySQLOpt     `yaml:"tidb"`
+	TiKV      *TiKVOpt      `yaml:"tikv"`
 }
 
 type OfflineStoreConfig struct {
@@ -43,6 +45,7 @@ type OfflineStoreConfig struct {
 	Snowflake *SnowflakeOpt `yaml:"snowflake"`
 	BigQuery  *BigQueryOpt  `yaml:"bigquery"`
 	Redshift  *RedshiftOpt  `yaml:"redshift"`
+	SQLite    *SQLiteOpt    `yaml:"sqlite"`
 	TiDB      *MySQLOpt     `yaml:"tidb"`
 }
 
@@ -140,6 +143,14 @@ func (cfg *MetadataStoreConfig) Validate() error {
 		cfg.Backend = BackendMySQL
 		n++
 	}
+	if cfg.SQLite != nil {
+		cfg.Backend = BackendSQLite
+		n++
+	}
+	if cfg.TiDB != nil {
+		cfg.Backend = BackendMySQL
+		n++
+	}
 	if n != 1 {
 		return fmt.Errorf("require exactly one metadata store backend")
 	}
@@ -164,6 +175,22 @@ func (cfg *OnlineStoreConfig) Validate() error {
 		cfg.Backend = BackendDynamoDB
 		n++
 	}
+	if cfg.Cassandra != nil {
+		cfg.Backend = BackendCassandra
+		n++
+	}
+	if cfg.SQLite != nil {
+		cfg.Backend = BackendSQLite
+		n++
+	}
+	if cfg.TiDB != nil {
+		cfg.Backend = BackendMySQL
+		n++
+	}
+	if cfg.TiKV != nil {
+		cfg.Backend = BackendTiKV
+		n++
+	}
 	if n != 1 {
 		return fmt.Errorf("require exactly one online store backend")
 	}
@@ -182,6 +209,22 @@ func (cfg *OfflineStoreConfig) Validate() error {
 	}
 	if cfg.Snowflake != nil {
 		cfg.Backend = BackendSnowflake
+		n++
+	}
+	if cfg.BigQuery != nil {
+		cfg.Backend = BackendBigQuery
+		n++
+	}
+	if cfg.Redshift != nil {
+		cfg.Backend = BackendRedshift
+		n++
+	}
+	if cfg.SQLite != nil {
+		cfg.Backend = BackendSQLite
+		n++
+	}
+	if cfg.TiDB != nil {
+		cfg.Backend = BackendMySQL
 		n++
 	}
 	if n != 1 {


### PR DESCRIPTION
It is so easy to forget. Let's come up with a way to prevent this. Running sanity integration test is one way.