### PR TITLE
Jinghan/create the first snapshot for streaming feature

### DIFF
--- a/pkg/oomstore/revision.go
+++ b/pkg/oomstore/revision.go
@@ -3,6 +3,12 @@ package oomstore
 import (
 	"context"
 
+	"github.com/oom-ai/oomstore/internal/database/offline"
+
+	"github.com/oom-ai/oomstore/internal/database/metadata/sqlutil"
+
+	"github.com/oom-ai/oomstore/internal/database/metadata"
+
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -19,4 +25,34 @@ func (s *OomStore) GetRevision(ctx context.Context, id int) (*types.Revision, er
 // Get metadata of a revision by group ID and revision.
 func (s *OomStore) GetRevisionBy(ctx context.Context, groupID int, revision int64) (*types.Revision, error) {
 	return s.metadata.GetRevisionBy(ctx, groupID, revision)
+}
+
+func (s *OomStore) createFirstSnapshotTable(ctx context.Context, revision *types.Revision) error {
+	snapshotTable := sqlutil.OfflineStreamSnapshotTableName(revision.GroupID, revision.Revision)
+
+	// Update snapshot_table in feature_group_revision table
+	err := s.metadata.UpdateRevision(ctx, metadata.UpdateRevisionOpt{
+		RevisionID:       revision.ID,
+		NewSnapshotTable: &snapshotTable,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Create snapshot table in offline store
+	features, err := s.metadata.ListFeature(ctx, metadata.ListFeatureOpt{
+		GroupID: &revision.GroupID,
+	})
+	if err != nil {
+		return err
+	}
+	if err = s.offline.CreateTable(ctx, offline.CreateTableOpt{
+		TableName: snapshotTable,
+		Entity:    revision.Group.Entity,
+		Features:  features,
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/oomstore/snapshot.go
+++ b/pkg/oomstore/snapshot.go
@@ -20,9 +20,17 @@ func (s *OomStore) Snapshot(ctx context.Context, groupName string) error {
 	if err != nil {
 		return err
 	}
+	if len(revisions) == 0 {
+		return nil
+	}
 	sort.Slice(revisions, func(i, j int) bool {
 		return revisions[i].Revision < revisions[j].Revision
 	})
+	if revisions[0].SnapshotTable == "" {
+		if err = s.createFirstSnapshotTable(ctx, revisions[0]); err != nil {
+			return err
+		}
+	}
 	for i, revision := range revisions {
 		if revision.SnapshotTable != "" {
 			continue


### PR DESCRIPTION
This PR implements method `createFirstSnapshotTable`. This function will create the first snapshot_table for a new `feature_group` when a user triggers API `Snapshot`.

close #862 