### PR TITLE
Feat/online query stream feature

### DIFF
--- a/internal/database/online/dynamodb/get.go
+++ b/internal/database/online/dynamodb/get.go
@@ -20,7 +20,13 @@ const (
 )
 
 func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error) {
-	tableName := sqlutil.OnlineBatchTableName(opt.RevisionID)
+	var tableName string
+	if opt.Group.Category == oomTypes.CategoryBatch {
+		tableName = sqlutil.OnlineBatchTableName(*opt.RevisionID)
+	} else {
+		tableName = sqlutil.OnlineStreamTableName(opt.Group.ID)
+	}
+
 	entityKeyValue, err := attributevalue.Marshal(opt.EntityKey)
 	if err != nil {
 		return nil, err
@@ -42,8 +48,14 @@ func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error)
 
 // response: map[entity_key]map[feature_name]feature_value
 func (db *DB) MultiGet(ctx context.Context, opt online.MultiGetOpt) (map[string]dbutil.RowMap, error) {
+	var tableName string
+	if opt.Group.Category == oomTypes.CategoryBatch {
+		tableName = sqlutil.OnlineBatchTableName(*opt.RevisionID)
+	} else {
+		tableName = sqlutil.OnlineStreamTableName(opt.Group.ID)
+	}
+
 	res := make(map[string]dbutil.RowMap)
-	tableName := sqlutil.OnlineBatchTableName(opt.RevisionID)
 	keys := make([]map[string]types.AttributeValue, 0, BatchGetItemCapacity)
 	for _, entityKey := range opt.EntityKeys {
 		entityKeyValue, err := attributevalue.Marshal(entityKey)

--- a/internal/database/online/sqlutil/get.go
+++ b/internal/database/online/sqlutil/get.go
@@ -14,8 +14,14 @@ import (
 )
 
 func Get(ctx context.Context, db *sqlx.DB, opt online.GetOpt, backend types.BackendType) (dbutil.RowMap, error) {
+	var tableName string
+	if opt.Group.Category == types.CategoryBatch {
+		tableName = OnlineBatchTableName(*opt.RevisionID)
+	} else {
+		tableName = OnlineStreamTableName(opt.Group.ID)
+	}
+
 	featureNames := opt.Features.Names()
-	tableName := OnlineBatchTableName(opt.RevisionID)
 	qt := dbutil.QuoteFn(backend)
 	query := fmt.Sprintf(`SELECT %s FROM %s WHERE %s = ?`, qt(featureNames...), qt(tableName), qt(opt.Entity.Name))
 
@@ -36,8 +42,14 @@ func Get(ctx context.Context, db *sqlx.DB, opt online.GetOpt, backend types.Back
 
 // response: map[entity_key]map[feature_name]feature_value
 func MultiGet(ctx context.Context, db *sqlx.DB, opt online.MultiGetOpt, backend types.BackendType) (map[string]dbutil.RowMap, error) {
+	var tableName string
+	if opt.Group.Category == types.CategoryBatch {
+		tableName = OnlineBatchTableName(*opt.RevisionID)
+	} else {
+		tableName = OnlineStreamTableName(opt.Group.ID)
+	}
+
 	featureNames := opt.Features.Names()
-	tableName := OnlineBatchTableName(opt.RevisionID)
 	qt := dbutil.QuoteFn(backend)
 	query := fmt.Sprintf(`SELECT %s, %s FROM %s WHERE %s in (?);`, qt(opt.Entity.Name), qt(featureNames...), qt(tableName), qt(opt.Entity.Name))
 	sql, args, err := sqlx.In(query, opt.EntityKeys)

--- a/internal/database/online/test_impl/get.go
+++ b/internal/database/online/test_impl/get.go
@@ -18,7 +18,8 @@ func TestGetExisted(t *testing.T, prepareStore PrepareStoreFn, destroyStore Dest
 	for _, target := range s.Data {
 		opt := online.GetOpt{
 			Entity:     s.Entity,
-			RevisionID: s.Revision.ID,
+			RevisionID: &s.Revision.ID,
+			Group:      s.Revision.Group,
 			Features:   s.Features,
 			EntityKey:  target.EntityKey(),
 		}
@@ -41,7 +42,8 @@ func TestGetNotExistedEntityKey(t *testing.T, prepareStore PrepareStoreFn, destr
 
 	rs, err := store.Get(ctx, online.GetOpt{
 		Entity:     s.Entity,
-		RevisionID: s.Revision.ID,
+		RevisionID: &s.Revision.ID,
+		Group:      s.Revision.Group,
 		Features:   s.Features,
 		EntityKey:  "not-existed-key",
 	})
@@ -63,7 +65,8 @@ func TestMultiGet(t *testing.T, prepareStore PrepareStoreFn, destroystore Destro
 	}
 	rs, err := store.MultiGet(ctx, online.MultiGetOpt{
 		Entity:     s.Entity,
-		RevisionID: s.Revision.ID,
+		RevisionID: &s.Revision.ID,
+		Group:      s.Revision.Group,
 		Features:   s.Features,
 		EntityKeys: keys,
 	})

--- a/internal/database/online/test_impl/purge.go
+++ b/internal/database/online/test_impl/purge.go
@@ -20,7 +20,8 @@ func TestPurgeRemovesSpecifiedRevision(t *testing.T, prepareStore PrepareStoreFn
 	for _, record := range SampleMedium.Data {
 		rs, err := store.Get(ctx, online.GetOpt{
 			Entity:     SampleMedium.Entity,
-			RevisionID: SampleMedium.Revision.ID,
+			RevisionID: &SampleMedium.Revision.ID,
+			Group:      SampleMedium.Revision.Group,
 			EntityKey:  record.EntityKey(),
 			Features:   SampleMedium.Features,
 		})
@@ -42,7 +43,8 @@ func TestPurgeNotRemovesOtherRevisions(t *testing.T, prepareStore PrepareStoreFn
 	for _, record := range SampleSmall.Data {
 		rs, err := store.Get(ctx, online.GetOpt{
 			Entity:     SampleSmall.Entity,
-			RevisionID: SampleSmall.Revision.ID,
+			RevisionID: &SampleSmall.Revision.ID,
+			Group:      SampleSmall.Revision.Group,
 			EntityKey:  record.EntityKey(),
 			Features:   SampleSmall.Features,
 		})

--- a/internal/database/online/test_impl/stream.go
+++ b/internal/database/online/test_impl/stream.go
@@ -131,6 +131,17 @@ func TestPush(t *testing.T, prepareStore PrepareStoreFn, destoryStore DestroySto
 		Features:      types.FeatureList{feature1},
 		FeatureValues: []interface{}{"post1"},
 	}))
+	rs, err := store.Get(ctx, online.GetOpt{
+		Entity:     &entity,
+		EntityKey:  "user1",
+		RevisionID: nil,
+		Group:      group,
+		Features:   types.FeatureList{feature1},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		feature1.FullName: "post1",
+	}, rs)
 
 	assert.NoError(t, store.Push(ctx, online.PushOpt{
 		Entity:        &entity,
@@ -139,6 +150,17 @@ func TestPush(t *testing.T, prepareStore PrepareStoreFn, destoryStore DestroySto
 		Features:      types.FeatureList{feature1},
 		FeatureValues: []interface{}{"post2"},
 	}))
+	rs, err = store.Get(ctx, online.GetOpt{
+		Entity:     &entity,
+		EntityKey:  "user1",
+		RevisionID: nil,
+		Group:      group,
+		Features:   types.FeatureList{feature1},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		feature1.FullName: "post2",
+	}, rs)
 
 	assert.NoError(t, store.PrepareStreamTable(ctx, online.PrepareStreamTableOpt{
 		Entity:  &entity,
@@ -153,4 +175,16 @@ func TestPush(t *testing.T, prepareStore PrepareStoreFn, destoryStore DestroySto
 		Features:      types.FeatureList{feature1, feature2},
 		FeatureValues: []interface{}{"post1", "post2"},
 	}))
+	rs, err = store.Get(ctx, online.GetOpt{
+		Entity:     &entity,
+		EntityKey:  "user1",
+		RevisionID: nil,
+		Group:      group,
+		Features:   types.FeatureList{feature1, feature2},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		feature1.FullName: "post1",
+		feature2.FullName: "post2",
+	}, rs)
 }

--- a/internal/database/online/test_impl/util.go
+++ b/internal/database/online/test_impl/util.go
@@ -39,6 +39,7 @@ func init() {
 					Name:      "age",
 					FullName:  "user.age",
 					GroupID:   1,
+					Group:     &types.Group{ID: 1, Category: types.CategoryBatch},
 					ValueType: types.Int64,
 				},
 				&types.Feature{
@@ -46,6 +47,7 @@ func init() {
 					Name:      "gender",
 					FullName:  "user.gender",
 					GroupID:   1,
+					Group:     &types.Group{ID: 1, Category: types.CategoryBatch},
 					ValueType: types.String,
 				},
 				&types.Feature{
@@ -53,6 +55,7 @@ func init() {
 					Name:      "account",
 					FullName:  "user.account",
 					GroupID:   1,
+					Group:     &types.Group{ID: 1, Category: types.CategoryBatch},
 					ValueType: types.Float64,
 				},
 				&types.Feature{
@@ -60,6 +63,7 @@ func init() {
 					Name:      "is_active",
 					FullName:  "user.is_active",
 					GroupID:   1,
+					Group:     &types.Group{ID: 1, Category: types.CategoryBatch},
 					ValueType: types.Bool,
 				},
 				&types.Feature{
@@ -67,11 +71,19 @@ func init() {
 					Name:      "register_time",
 					FullName:  "user.register_time",
 					GroupID:   1,
+					Group:     &types.Group{ID: 1, Category: types.CategoryBatch},
 					ValueType: types.Time,
 				},
 			},
-			Revision: &types.Revision{ID: 3, GroupID: 1},
-			Entity:   &types.Entity{ID: 5, Name: "user", Length: 4},
+			Revision: &types.Revision{
+				ID:      3,
+				GroupID: 1,
+				Group: &types.Group{
+					ID:       1,
+					Category: types.CategoryBatch,
+				},
+			},
+			Entity: &types.Entity{ID: 5, Name: "user", Length: 4},
 			Data: []types.ExportRecord{
 				[]interface{}{"3215", int64(18), "F", 1.1, true, time.Now()},
 				[]interface{}{"3216", int64(29), nil, 2.0, false, time.Now()},
@@ -88,11 +100,12 @@ func init() {
 				Name:      "charge",
 				FullName:  "user.charge",
 				GroupID:   2,
+				Group:     &types.Group{ID: 2, Category: types.CategoryBatch},
 				ValueType: types.Float64,
 			},
 		}
 
-		revision := &types.Revision{ID: 9, GroupID: 2}
+		revision := &types.Revision{ID: 9, GroupID: 2, Group: &types.Group{ID: 2, Category: types.CategoryBatch}}
 		entity := &types.Entity{ID: 5, Name: "user", Length: 5}
 		var data []types.ExportRecord
 

--- a/internal/database/online/types.go
+++ b/internal/database/online/types.go
@@ -6,15 +6,17 @@ import (
 
 type GetOpt struct {
 	Entity     *types.Entity
-	RevisionID int
 	EntityKey  string
+	RevisionID *int
+	Group      *types.Group
 	Features   types.FeatureList
 }
 
 type MultiGetOpt struct {
 	Entity     *types.Entity
-	RevisionID int
 	EntityKeys []string
+	RevisionID *int
+	Group      *types.Group
 	Features   types.FeatureList
 }
 

--- a/pkg/oomstore/online_query_test.go
+++ b/pkg/oomstore/online_query_test.go
@@ -25,7 +25,6 @@ func TestOnlineGet(t *testing.T) {
 	entityName := "device"
 	consistentFeatures := prepareFeatures(true, true)
 	inconsistentFeatures := prepareFeatures(false, true)
-	unavailableFeatures := prepareFeatures(true, false)
 
 	testCases := []struct {
 		description   string
@@ -38,14 +37,14 @@ func TestOnlineGet(t *testing.T) {
 		{
 			description: "no available features",
 			opt: types.OnlineGetOpt{
-				FeatureFullNames: unavailableFeatures.FullNames(),
+				FeatureFullNames: []string{"f1", "f2"},
 				EntityKey:        "1234",
 			},
-			features:      unavailableFeatures,
+			features:      nil,
 			expectedError: nil,
 			expected: &types.FeatureValues{
 				EntityKey:        "1234",
-				FeatureFullNames: consistentFeatures.FullNames(),
+				FeatureFullNames: []string{"f1", "f2"},
 				FeatureValueMap:  map[string]interface{}{},
 			},
 		},
@@ -113,7 +112,6 @@ func TestOnlineMultiGet(t *testing.T) {
 	entityName := "device"
 	consistentFeatures := prepareFeatures(true, true)
 	inconsistentFeatures := prepareFeatures(false, true)
-	unavailableFeatures := prepareFeatures(true, false)
 
 	testCases := []struct {
 		description   string
@@ -126,10 +124,10 @@ func TestOnlineMultiGet(t *testing.T) {
 		{
 			description: "no available features, return nil",
 			opt: types.OnlineMultiGetOpt{
-				FeatureFullNames: unavailableFeatures.FullNames(),
+				FeatureFullNames: []string{"f1", "f2"},
 				EntityKeys:       []string{"1234", "1235"},
 			},
-			features:      unavailableFeatures,
+			features:      nil,
 			expectedError: nil,
 			expected:      map[string]*types.FeatureValues{},
 		},

--- a/pkg/oomstore/types/feature.go
+++ b/pkg/oomstore/types/feature.go
@@ -35,6 +35,9 @@ func (f *Feature) Entity() *Entity {
 }
 
 func (f *Feature) OnlineRevisionID() *int {
+	if f.Group.Category == CategoryStream {
+		return nil
+	}
 	return f.Group.OnlineRevisionID
 }
 


### PR DESCRIPTION
this PR does:
1. modified `GetOpt` and `GetMulOpt`: add field `GroupID` and make `RevisionID` to pointer.
2. online Dbs support gets stream feature.
3. oomstore online query support get stream feature.
4. add unit test for getting stream feature
5. fix Cassandra get/multi-get bug