### PR TITLE
Jinghan/implement API `ChannelExportStream`

### DIFF
--- a/internal/database/offline/types.go
+++ b/internal/database/offline/types.go
@@ -8,6 +8,8 @@ import (
 
 type ExportOpt struct {
 	SnapshotTable string
+	CdcTable      *string
+	UnixMilli     *int64
 	EntityName    string
 	Features      types.FeatureList
 	Limit         *uint64

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -36,6 +36,12 @@ type ChannelExportOpt struct {
 	Limit        *uint64
 }
 
+type ChannelExportStreamOpt struct {
+	UnixMilli        int64
+	FeatureFullNames []string
+	Limit            *uint64
+}
+
 type ExportOpt struct {
 	RevisionID     int
 	FeatureNames   []string

--- a/pkg/oomstore/types/revision.go
+++ b/pkg/oomstore/types/revision.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"sort"
 	"time"
 )
 
@@ -60,6 +61,25 @@ func (l RevisionList) Filter(filter func(*Revision) bool) (rs RevisionList) {
 		}
 	}
 	return
+}
+
+func (l RevisionList) Before(unixMilli int64) *Revision {
+	if len(l) == 0 {
+		return nil
+	}
+	sort.Slice(l, func(i, j int) bool {
+		return l[i].Revision < l[j].Revision
+	})
+	if l[0].Revision > unixMilli {
+		return nil
+	}
+	var i int
+	for i = range l {
+		if l[i].Revision > unixMilli {
+			break
+		}
+	}
+	return l[i-1]
 }
 
 func (l RevisionList) GroupIDs() []int {


### PR DESCRIPTION
This PR adds a new API `ChannelExportStream`, which exports stream feature values given a timestamp.

TODO:
- [ ] modify offline method `Export`: support exporting streaming features

related to #802 