### PR TITLE
chore:  print error stack by environment

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -3,8 +3,8 @@ package database
 import (
 	"context"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	metadataMySQL "github.com/oom-ai/oomstore/internal/database/metadata/mysql"
@@ -48,7 +48,7 @@ func OpenOnlineStore(opt types.OnlineStoreConfig) (online.Store, error) {
 	case types.BackendTiKV:
 		return onlineTiKV.Open(opt.TiKV)
 	default:
-		return nil, errors.Errorf("unsupported backend: %s", opt.Backend)
+		return nil, errdefs.Errorf("unsupported backend: %s", opt.Backend)
 	}
 }
 
@@ -63,7 +63,7 @@ func OpenMetadataStore(opt types.MetadataStoreConfig) (metadata.Store, error) {
 	case types.BackendSQLite:
 		return metadataSQLite.Open(context.Background(), opt.SQLite)
 	default:
-		return nil, errors.Errorf("unsupported backend: %s", opt.Backend)
+		return nil, errdefs.Errorf("unsupported backend: %s", opt.Backend)
 	}
 }
 
@@ -78,7 +78,7 @@ func CreateMetadataDatabase(ctx context.Context, opt types.MetadataStoreConfig) 
 	case types.BackendSQLite:
 		return metadataSQLite.CreateDatabase(ctx, opt.SQLite)
 	default:
-		return errors.Errorf("unsupported backend: %s", opt.Backend)
+		return errdefs.Errorf("unsupported backend: %s", opt.Backend)
 	}
 }
 
@@ -99,6 +99,6 @@ func OpenOfflineStore(ctx context.Context, opt types.OfflineStoreConfig) (offlin
 	case types.BackendSQLite:
 		return offlineSQLite.Open(opt.SQLite)
 	default:
-		return nil, errors.Errorf("unsupported backend: %s", opt.Backend)
+		return nil, errdefs.Errorf("unsupported backend: %s", opt.Backend)
 	}
 }

--- a/internal/database/dbutil/data_loader.go
+++ b/internal/database/dbutil/data_loader.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/offline"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -24,7 +24,7 @@ func loadDataFromSource(tx *sqlx.Tx, ctx context.Context, source *offline.CSVSou
 	records := make([]interface{}, 0, batchSize)
 	for {
 		record, err := ReadLine(source.Reader, source.Delimiter, features, backendType)
-		if errors.Cause(err) == io.EOF {
+		if errdefs.Cause(err) == io.EOF {
 			break
 		}
 		if err != nil {
@@ -50,7 +50,7 @@ func loadDataFromSource(tx *sqlx.Tx, ctx context.Context, source *offline.CSVSou
 func ReadLine(reader *bufio.Reader, delimiter string, features types.FeatureList, backend types.BackendType) ([]interface{}, error) {
 	row, err := reader.ReadString('\n')
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	rowSlice := strings.Split(strings.Trim(row, "\n"), delimiter)
 	line := make([]interface{}, 0, len(rowSlice))

--- a/internal/database/dbutil/database.go
+++ b/internal/database/dbutil/database.go
@@ -7,8 +7,8 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 	"github.com/snowflakedb/gosnowflake"
 	"google.golang.org/api/googleapi"
 	"modernc.org/sqlite"
@@ -17,7 +17,7 @@ import (
 
 func OpenSQLite(dbFile string) (*sqlx.DB, error) {
 	db, err := sqlx.Open("sqlite", dbFile)
-	return db, errors.WithStack(err)
+	return db, errdefs.WithStack(err)
 }
 
 func OpenMysqlDB(host, port, user, password, database string) (*sqlx.DB, error) {
@@ -29,7 +29,7 @@ func OpenMysqlDB(host, port, user, password, database string) (*sqlx.DB, error) 
 	cfg.ParseTime = true
 
 	db, err := sqlx.Open("mysql", cfg.FormatDSN())
-	return db, errors.WithStack(err)
+	return db, errdefs.WithStack(err)
 }
 
 func OpenPostgresDB(host, port, user, password, database string) (*sqlx.DB, error) {
@@ -42,14 +42,14 @@ func OpenPostgresDB(host, port, user, password, database string) (*sqlx.DB, erro
 			port,
 			database),
 	)
-	return db, errors.WithStack(err)
+	return db, errdefs.WithStack(err)
 }
 
 var OpenRedshiftDB = OpenPostgresDB
 
 // TODO: Should return an error when bakcend is not supported ?
 func IsTableNotFoundError(err error, backend types.BackendType) bool {
-	err = errors.Cause(err)
+	err = errdefs.Cause(err)
 	switch backend {
 	case types.BackendSQLite:
 		if sqliteErr, ok := err.(*sqlite.Error); ok {

--- a/internal/database/dbutil/db_opt.go
+++ b/internal/database/dbutil/db_opt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 
 	"cloud.google.com/go/bigquery"
@@ -31,10 +31,10 @@ func (d *DBOpt) ExecContext(ctx context.Context, query string, args []interface{
 			query = strings.Replace(query, "?", cast.ToString(arg), 1)
 		}
 		_, err := d.BigQueryDB.Query(query).Read(ctx)
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	default:
 		_, err := d.SqlxDB.ExecContext(ctx, d.SqlxDB.Rebind(query), args...)
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 }
 
@@ -57,5 +57,5 @@ func (d *DBOpt) BuildInsertQuery(tableName string, records []interface{}, column
 	query, args, err := sqlx.In(
 		fmt.Sprintf(`INSERT INTO %s (%s) VALUES %s`, tableName, columnStr, strings.Join(valueFlags, ",")),
 		records...)
-	return query, args, errors.WithStack(err)
+	return query, args, errdefs.WithStack(err)
 }

--- a/internal/database/dbutil/deserialize.go
+++ b/internal/database/dbutil/deserialize.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cast"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 func DeserializeByValueType(i interface{}, valueType types.ValueType, backend types.BackendType) (interface{}, error) {
@@ -35,7 +35,7 @@ func DeserializeByValueType(i interface{}, valueType types.ValueType, backend ty
 
 	value, err := deserializer(i, valueType)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return value, nil
 }
@@ -49,7 +49,7 @@ func rdbDeserializer(i interface{}, valueType types.ValueType) (interface{}, err
 		} else if s == "0" || s == "false" {
 			return false, nil
 		}
-		return nil, errors.Errorf("invalid bool value %v", i)
+		return nil, errdefs.Errorf("invalid bool value %v", i)
 	case types.String:
 		return cast.ToString(i), nil
 	default:
@@ -72,13 +72,13 @@ func dynamoDeserializer(i interface{}, valueType types.ValueType) (interface{}, 
 	case types.Int64:
 		v, ok := i.(float64)
 		if !ok {
-			return "", errors.Errorf("not float64 %v", i)
+			return "", errdefs.Errorf("not float64 %v", i)
 		}
 		return int64(v), nil
 	case types.Time:
 		v, ok := i.(float64)
 		if !ok {
-			return "", errors.Errorf("not float64 %v", i)
+			return "", errdefs.Errorf("not float64 %v", i)
 		}
 		return time.UnixMilli(int64(v)), nil
 	default:
@@ -96,7 +96,7 @@ func snowflakeDeserializer(i interface{}, valueType types.ValueType) (interface{
 
 	s, ok := i.(string)
 	if !ok {
-		return nil, errors.Errorf("not a string or nil: %v", i)
+		return nil, errdefs.Errorf("not a string or nil: %v", i)
 	}
 
 	switch valueType {
@@ -105,11 +105,11 @@ func snowflakeDeserializer(i interface{}, valueType types.ValueType) (interface{
 
 	case types.Int64:
 		x, err := strconv.ParseInt(s, 10, 64)
-		return x, errors.WithStack(err)
+		return x, errdefs.WithStack(err)
 
 	case types.Float64:
 		x, err := strconv.ParseFloat(s, 64)
-		return x, errors.WithStack(err)
+		return x, errdefs.WithStack(err)
 
 	case types.Bool:
 		if s == "1" {
@@ -117,7 +117,7 @@ func snowflakeDeserializer(i interface{}, valueType types.ValueType) (interface{
 		} else if s == "0" {
 			return false, nil
 		} else {
-			return nil, errors.Errorf("invalid bool value: %s", s)
+			return nil, errdefs.Errorf("invalid bool value: %s", s)
 		}
 	case types.Time:
 		x, err := strconv.ParseInt(s, 10, 64)
@@ -126,7 +126,7 @@ func snowflakeDeserializer(i interface{}, valueType types.ValueType) (interface{
 	case types.Bytes:
 		return []byte(s), nil
 	default:
-		return "", errors.Errorf("unsupported value type: %s", valueType)
+		return "", errdefs.Errorf("unsupported value type: %s", valueType)
 	}
 }
 
@@ -137,7 +137,7 @@ func kvDeserializer(i interface{}, valueType types.ValueType) (interface{}, erro
 
 	s, ok := i.(string)
 	if !ok {
-		return nil, errors.Errorf("not a string or nil: %v", i)
+		return nil, errdefs.Errorf("not a string or nil: %v", i)
 	}
 
 	switch valueType {
@@ -158,7 +158,7 @@ func kvDeserializer(i interface{}, valueType types.ValueType) (interface{}, erro
 		} else if s == "0" {
 			return false, nil
 		} else {
-			return nil, errors.Errorf("invalid bool value: %s", s)
+			return nil, errdefs.Errorf("invalid bool value: %s", s)
 		}
 	case types.Time:
 		x, err := strconv.ParseInt(s, serializeIntBase, 64)
@@ -167,6 +167,6 @@ func kvDeserializer(i interface{}, valueType types.ValueType) (interface{}, erro
 	case types.Bytes:
 		return []byte(s), nil
 	default:
-		return "", errors.Errorf("unsupported value type: %s", valueType)
+		return "", errdefs.Errorf("unsupported value type: %s", valueType)
 	}
 }

--- a/internal/database/dbutil/serialize.go
+++ b/internal/database/dbutil/serialize.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -29,7 +29,7 @@ func SerializeByValueType(i interface{}, valueType types.ValueType, backend type
 
 	value, err := serializer(i, valueType)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return value, nil
 }
@@ -37,7 +37,7 @@ func SerializeByValueType(i interface{}, valueType types.ValueType, backend type
 func kvSerializerByValueType(i interface{}, valueType types.ValueType) (s interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.Errorf("failed to serailize by tag: %v", r)
+			err = errdefs.Errorf("failed to serailize by tag: %v", r)
 		}
 	}()
 
@@ -60,14 +60,14 @@ func kvSerializerByValueType(i interface{}, valueType types.ValueType) (s interf
 	case types.Bytes:
 		return string(i.([]byte)), nil
 	default:
-		return "", errors.Errorf("unable to serialize %#v of type %T to string", i, i)
+		return "", errdefs.Errorf("unable to serialize %#v of type %T to string", i, i)
 	}
 }
 
 func dynamoSerializerByValueType(i interface{}, valueType types.ValueType) (out interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.Errorf("failed to serailize by value type: %v", r)
+			err = errdefs.Errorf("failed to serailize by value type: %v", r)
 		}
 	}()
 
@@ -93,7 +93,7 @@ func SerializeByValue(i interface{}, backend types.BackendType) (string, error) 
 
 	value, err := serializer(i)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", errdefs.WithStack(err)
 	}
 	return value, nil
 }
@@ -142,6 +142,6 @@ func kvSerializerByValue(i interface{}) (string, error) {
 		}
 
 	default:
-		return "", errors.Errorf("unable to serialize %#v of type %T to string", i, i)
+		return "", errdefs.Errorf("unable to serialize %#v of type %T to string", i, i)
 	}
 }

--- a/internal/database/dbutil/sql.go
+++ b/internal/database/dbutil/sql.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -21,7 +21,7 @@ func BuildConditions(equal map[string]interface{}, in map[string]interface{}) ([
 	for key, value := range in {
 		s, inArgs, err := sqlx.In(fmt.Sprintf("%s IN (?)", key), value)
 		if err != nil {
-			return nil, nil, errors.WithStack(err)
+			return nil, nil, errdefs.WithStack(err)
 		}
 		cond = append(cond, s)
 		args = append(args, inArgs...)
@@ -53,7 +53,7 @@ func InsertRecordsToTableTx(tx *sqlx.Tx, ctx context.Context, tableName string, 
 		return nil
 	}
 	if _, err := tx.ExecContext(ctx, tx.Rebind(query), args...); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	return nil
 }
@@ -66,7 +66,7 @@ func GetColumnFormat(backendType types.BackendType) (string, error) {
 	case types.BackendMySQL, types.BackendSQLite, types.BackendBigQuery:
 		columnFormat = "`%s` %s"
 	default:
-		return "", errors.Errorf("unsupported backend type %s", backendType)
+		return "", errdefs.Errorf("unsupported backend type %s", backendType)
 	}
 	return columnFormat, nil
 }

--- a/internal/database/dbutil/type_mapping.go
+++ b/internal/database/dbutil/type_mapping.go
@@ -3,8 +3,6 @@ package dbutil
 import (
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -29,12 +27,12 @@ func DBValueType(backend types.BackendType, valueType types.ValueType) (string, 
 	case types.BackendBigQuery:
 		mp = valueTypeToBigQueryType
 	default:
-		return "", errdefs.InvalidAttribute(errors.Errorf("unsupported backend: %s", backend))
+		return "", errdefs.InvalidAttribute(errdefs.Errorf("unsupported backend: %s", backend))
 	}
 
 	t, ok := mp[valueType]
 	if !ok {
-		return "", errdefs.InvalidAttribute(errors.Errorf("unsupported value type: %s", valueType))
+		return "", errdefs.InvalidAttribute(errdefs.Errorf("unsupported value type: %s", valueType))
 	}
 	return t, nil
 }
@@ -56,7 +54,7 @@ func ValueType(backend types.BackendType, dbValueType string) (types.ValueType, 
 	case types.BackendRedshift:
 		mp = redshiftTypeToValueType
 	default:
-		return 0, errdefs.InvalidAttribute(errors.Errorf("unsupported backend: %s", backend))
+		return 0, errdefs.InvalidAttribute(errdefs.Errorf("unsupported backend: %s", backend))
 	}
 	dbValueType = strings.ToLower(dbValueType)
 	i := strings.Index(dbValueType, "(")
@@ -65,7 +63,7 @@ func ValueType(backend types.BackendType, dbValueType string) (types.ValueType, 
 	}
 	t, ok := mp[dbValueType]
 	if !ok {
-		return 0, errdefs.InvalidAttribute(errors.Errorf("unsupported db value type: %s", dbValueType))
+		return 0, errdefs.InvalidAttribute(errdefs.Errorf("unsupported db value type: %s", dbValueType))
 	}
 
 	return t, nil

--- a/internal/database/metadata/mysql/entity.go
+++ b/internal/database/metadata/mysql/entity.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
 func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateEntityOpt) (int, error) {
@@ -14,15 +14,15 @@ func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadat
 	if err != nil {
 		if er, ok := err.(*mysql.MySQLError); ok {
 			if er.Number == ER_DUP_ENTRY {
-				return 0, errors.Errorf("entity %s already exists", opt.EntityName)
+				return 0, errdefs.Errorf("entity %s already exists", opt.EntityName)
 			}
 		}
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 
 	entityID, err := res.LastInsertId()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 	return int(entityID), nil
 }

--- a/internal/database/metadata/mysql/feature.go
+++ b/internal/database/metadata/mysql/feature.go
@@ -3,7 +3,7 @@ package mysql
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
@@ -11,14 +11,14 @@ import (
 
 func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateFeatureOpt) (int, error) {
 	if err := opt.ValueType.Validate(); err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 	query := "INSERT INTO feature(name, full_name, group_id, value_type, description) VALUES (?, ?, ?, ?, ?)"
 	res, err := sqlxCtx.ExecContext(ctx, sqlxCtx.Rebind(query), opt.FeatureName, opt.FullName, opt.GroupID, opt.ValueType, opt.Description)
 	if err != nil {
 		if er, ok := err.(*mysql.MySQLError); ok {
 			if er.Number == ER_DUP_ENTRY {
-				return 0, errors.Errorf("feature %s already exists", opt.FeatureName)
+				return 0, errdefs.Errorf("feature %s already exists", opt.FeatureName)
 			}
 		}
 		return 0, err
@@ -26,7 +26,7 @@ func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metada
 
 	featureID, err := res.LastInsertId()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 	return int(featureID), nil
 }

--- a/internal/database/metadata/mysql/group.go
+++ b/internal/database/metadata/mysql/group.go
@@ -3,8 +3,6 @@ package mysql
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/go-sql-driver/mysql"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -13,7 +11,7 @@ import (
 
 func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateGroupOpt) (int, error) {
 	if opt.Category != types.CategoryBatch && opt.Category != types.CategoryStream {
-		return 0, errdefs.InvalidAttribute(errors.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category))
+		return 0, errdefs.InvalidAttribute(errdefs.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category))
 	}
 
 	query := "INSERT INTO feature_group(name, entity_id, category, description) VALUES(?, ?, ?, ?)"
@@ -21,15 +19,15 @@ func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata
 	if err != nil {
 		if er, ok := err.(*mysql.MySQLError); ok {
 			if er.Number == ER_DUP_ENTRY {
-				return 0, errors.Errorf("feature group %s already exists", opt.GroupName)
+				return 0, errdefs.Errorf("feature group %s already exists", opt.GroupName)
 			}
 		}
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 
 	groupID, err := res.LastInsertId()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 
 	return int(groupID), nil

--- a/internal/database/metadata/mysql/store.go
+++ b/internal/database/metadata/mysql/store.go
@@ -10,8 +10,8 @@ import (
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/internal/database/metadata/informer"
 	"github.com/oom-ai/oomstore/internal/database/metadata/sqlutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 var _ metadata.Store = &DB{}
@@ -32,10 +32,10 @@ func (db *DB) Ping(ctx context.Context) error {
 
 func (db *DB) Close() error {
 	if err := db.Informer.Close(); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	if err := db.DB.Close(); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	return nil
 }
@@ -63,17 +63,17 @@ func Open(ctx context.Context, option *types.MySQLOpt) (*DB, error) {
 func CreateDatabase(ctx context.Context, opt *types.MySQLOpt) error {
 	defaultDB, err := dbutil.OpenMysqlDB(opt.Host, opt.Port, opt.User, opt.Password, "")
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	defer defaultDB.Close()
 
 	if _, err = defaultDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", opt.Database)); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	db, err := dbutil.OpenMysqlDB(opt.Host, opt.Port, opt.User, opt.Password, opt.Database)
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	defer db.Close()
 	return createMetaSchemas(ctx, db)
@@ -86,21 +86,21 @@ func createMetaSchemas(ctx context.Context, db *sqlx.DB) (err error) {
 		// create meta tables
 		for _, schema := range META_TABLE_SCHEMAS {
 			if _, err = tx.ExecContext(ctx, schema); err != nil {
-				return errors.Errorf("failed to create table, err=%+v", err)
+				return errdefs.Errorf("failed to create table, err=%+v", err)
 			}
 		}
 
 		// create foreign keys
 		for _, stmt := range META_TABLE_FOREIGN_KEYS {
 			if _, err = tx.ExecContext(ctx, stmt); err != nil {
-				return errors.Errorf("failed to add foreign key, err=%+v", err)
+				return errdefs.Errorf("failed to add foreign key, err=%+v", err)
 			}
 		}
 
 		// create meta views
 		for _, schema := range META_VIEW_SCHEMAS {
 			if _, err = tx.ExecContext(ctx, schema); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 

--- a/internal/database/metadata/postgres/create_database.go
+++ b/internal/database/metadata/postgres/create_database.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -23,7 +23,7 @@ func CreateDatabase(ctx context.Context, opt *types.PostgresOpt) (err error) {
 
 	if _, err = defaultDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", opt.Database)); err != nil {
 		if e2, ok := err.(*pq.Error); ok && e2.Code != pgerrcode.DuplicateDatabase {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 	}
 
@@ -42,28 +42,28 @@ func createMetaSchemas(ctx context.Context, db *sqlx.DB) (err error) {
 		// create database functions
 		for _, fn := range DB_FUNCTIONS {
 			if _, err = tx.ExecContext(ctx, fn); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 
 		// create meta tables
 		for _, schema := range META_TABLE_SCHEMAS {
 			if _, err = tx.ExecContext(ctx, schema); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 
 		// create foreign keys
 		for _, stmt := range META_TABLE_FOREIGN_KEYS {
 			if _, err = tx.ExecContext(ctx, stmt); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 
 		// create meta views
 		for _, schema := range META_VIEW_SCHEMAS {
 			if _, err = tx.ExecContext(ctx, schema); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 
@@ -71,7 +71,7 @@ func createMetaSchemas(ctx context.Context, db *sqlx.DB) (err error) {
 		for table := range META_TABLE_SCHEMAS {
 			trigger := strings.ReplaceAll(TRIGGER_TEMPLATE, `{{TABLE_NAME}}`, table)
 			if _, err = tx.ExecContext(ctx, trigger); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 

--- a/internal/database/metadata/postgres/entity.go
+++ b/internal/database/metadata/postgres/entity.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jackc/pgerrcode"
 	"github.com/lib/pq"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 )
@@ -16,8 +16,8 @@ func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadat
 	err := sqlxCtx.GetContext(ctx, &entityID, query, opt.EntityName, opt.Description)
 	if er, ok := err.(*pq.Error); ok {
 		if er.Code == pgerrcode.UniqueViolation {
-			return 0, errors.Errorf("entity %s already exists", opt.EntityName)
+			return 0, errdefs.Errorf("entity %s already exists", opt.EntityName)
 		}
 	}
-	return entityID, errors.WithStack(err)
+	return entityID, errdefs.WithStack(err)
 }

--- a/internal/database/metadata/postgres/feature.go
+++ b/internal/database/metadata/postgres/feature.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/lib/pq"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
 func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateFeatureOpt) (int, error) {
@@ -19,9 +19,9 @@ func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metada
 	if err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
-				return 0, errors.Errorf("feature %s already exists", opt.FeatureName)
+				return 0, errdefs.Errorf("feature %s already exists", opt.FeatureName)
 			}
 		}
 	}
-	return featureID, errors.WithStack(err)
+	return featureID, errdefs.WithStack(err)
 }

--- a/internal/database/metadata/postgres/group.go
+++ b/internal/database/metadata/postgres/group.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jackc/pgerrcode"
 	"github.com/lib/pq"
-	"github.com/pkg/errors"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -14,7 +13,7 @@ import (
 
 func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateGroupOpt) (int, error) {
 	if opt.Category != types.CategoryBatch && opt.Category != types.CategoryStream {
-		return 0, errdefs.InvalidAttribute(errors.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category))
+		return 0, errdefs.InvalidAttribute(errdefs.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category))
 	}
 	var groupID int
 	query := "insert into feature_group(name, entity_id, category, description) values($1, $2, $3, $4) returning id"
@@ -22,9 +21,9 @@ func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata
 	if err != nil {
 		if e2, ok := err.(*pq.Error); ok {
 			if e2.Code == pgerrcode.UniqueViolation {
-				return 0, errors.Errorf("feature group %s already exists", opt.GroupName)
+				return 0, errdefs.Errorf("feature group %s already exists", opt.GroupName)
 			}
 		}
 	}
-	return groupID, errors.WithStack(err)
+	return groupID, errdefs.WithStack(err)
 }

--- a/internal/database/metadata/postgres/store.go
+++ b/internal/database/metadata/postgres/store.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/metadata/sqlutil"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/internal/database/metadata/informer"
@@ -56,7 +56,7 @@ func (db *DB) Close() error {
 		return err
 	}
 	if err := db.DB.Close(); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	return nil
 }

--- a/internal/database/metadata/sqlite/create_database.go
+++ b/internal/database/metadata/sqlite/create_database.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -24,20 +24,20 @@ func createMetaSchemas(ctx context.Context, db *sqlx.DB) (err error) {
 	return dbutil.WithTransaction(db, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 		for _, schema := range META_TABLE_SCHEMAS {
 			if _, err = tx.ExecContext(ctx, schema); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 
 		for _, schema := range META_VIEW_SCHEMAS {
 			if _, err = tx.ExecContext(ctx, schema); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 
 		for table := range META_TABLE_SCHEMAS {
 			trigger := strings.ReplaceAll(TRIGGER_TEMPLATE, `{{TABLE_NAME}}`, table)
 			if _, err = tx.ExecContext(ctx, trigger); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 

--- a/internal/database/metadata/sqlite/entity.go
+++ b/internal/database/metadata/sqlite/entity.go
@@ -3,7 +3,7 @@ package sqlite
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 
@@ -16,7 +16,7 @@ func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadat
 	if err != nil {
 		if er, ok := err.(*sqlite.Error); ok {
 			if er.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-				return 0, errors.Errorf("entity %s already exists", opt.EntityName)
+				return 0, errdefs.Errorf("entity %s already exists", opt.EntityName)
 			}
 		}
 
@@ -25,7 +25,7 @@ func createEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadat
 
 	entityID, err := res.LastInsertId()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 	return int(entityID), nil
 }

--- a/internal/database/metadata/sqlite/feature.go
+++ b/internal/database/metadata/sqlite/feature.go
@@ -3,7 +3,7 @@ package sqlite
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 
@@ -19,15 +19,15 @@ func createFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metada
 	if err != nil {
 		if sqliteErr, ok := err.(*sqlite.Error); ok {
 			if sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-				return 0, errors.Errorf("feature %s already exists", opt.FeatureName)
+				return 0, errdefs.Errorf("feature %s already exists", opt.FeatureName)
 			}
 		}
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 
 	featureID, err := res.LastInsertId()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 	return int(featureID), nil
 }

--- a/internal/database/metadata/sqlite/group.go
+++ b/internal/database/metadata/sqlite/group.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 
@@ -14,7 +13,7 @@ import (
 
 func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.CreateGroupOpt) (int, error) {
 	if opt.Category != types.CategoryBatch && opt.Category != types.CategoryStream {
-		return 0, errdefs.InvalidAttribute(errors.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category))
+		return 0, errdefs.InvalidAttribute(errdefs.Errorf("illegal category '%s', should be either 'stream' or 'batch'", opt.Category))
 	}
 
 	query := "INSERT INTO feature_group(name, entity_id, category, description) VALUES(?, ?, ?, ?)"
@@ -22,15 +21,15 @@ func createGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata
 	if err != nil {
 		if sqliteErr, ok := err.(*sqlite.Error); ok {
 			if sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
-				return 0, errors.Errorf("feature group %s already exists", opt.GroupName)
+				return 0, errdefs.Errorf("feature group %s already exists", opt.GroupName)
 			}
 		}
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 
 	groupID, err := res.LastInsertId()
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, errdefs.WithStack(err)
 	}
 
 	return int(groupID), nil

--- a/internal/database/metadata/sqlite/store.go
+++ b/internal/database/metadata/sqlite/store.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/oom-ai/oomstore/internal/database/metadata/informer"
 	"github.com/oom-ai/oomstore/internal/database/metadata/sqlutil"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 
@@ -55,7 +55,7 @@ func (db *DB) Close() error {
 		return err
 	}
 	if err := db.DB.Close(); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	return nil
 }

--- a/internal/database/metadata/sqlutil/db.go
+++ b/internal/database/metadata/sqlutil/db.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/metadata/informer"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -16,17 +16,17 @@ func ListMetadata(ctx context.Context, db *sqlx.DB) (*informer.Cache, error) {
 	err := dbutil.WithTransaction(db, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 		entities := types.EntityList{}
 		if err := tx.SelectContext(ctx, &entities, `SELECT * FROM entity`); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 
 		features := types.FeatureList{}
 		if err := tx.SelectContext(ctx, &features, `SELECT * FROM feature`); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 
 		groups := types.GroupList{}
 		if err := tx.SelectContext(ctx, &groups, `SELECT * FROM feature_group`); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 
 		cache = informer.NewCache(entities, features, groups)

--- a/internal/database/metadata/sqlutil/entity.go
+++ b/internal/database/metadata/sqlutil/entity.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -15,22 +13,22 @@ import (
 
 func UpdateEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata.UpdateEntityOpt) error {
 	if opt.NewDescription == nil {
-		return errors.Errorf("invalid option: nothing to update")
+		return errdefs.Errorf("invalid option: nothing to update")
 	}
 
 	query := "UPDATE entity SET description = ? WHERE id = ?"
 	result, err := sqlxCtx.ExecContext(ctx, sqlxCtx.Rebind(query), opt.NewDescription, opt.EntityID)
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	if rowsAffected != 1 {
-		return errors.Errorf("failed to update entity %d: entity not found", opt.EntityID)
+		return errdefs.Errorf("failed to update entity %d: entity not found", opt.EntityID)
 	}
 	return nil
 }
@@ -40,9 +38,9 @@ func GetEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, id int) (*type
 	query := "SELECT * FROM entity WHERE id = ?"
 	if err := sqlxCtx.GetContext(ctx, &entity, sqlxCtx.Rebind(query), id); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(errors.Errorf("feature entity %d not found", id))
+			return nil, errdefs.NotFound(errdefs.Errorf("feature entity %d not found", id))
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	return &entity, nil
@@ -53,9 +51,9 @@ func GetEntityByName(ctx context.Context, sqlxCtx metadata.SqlxContext, name str
 	query := "SELECT * FROM entity WHERE name = ?"
 	if err := sqlxCtx.GetContext(ctx, &entity, sqlxCtx.Rebind(query), name); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(errors.Errorf("feature entity %s not found", name))
+			return nil, errdefs.NotFound(errdefs.Errorf("feature entity %s not found", name))
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	return &entity, nil
@@ -71,12 +69,12 @@ func ListEntity(ctx context.Context, sqlxCtx metadata.SqlxContext, entityIDs *[]
 		}
 		query, args, err = sqlx.In(fmt.Sprintf("%s WHERE id IN (?)", query), *entityIDs)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errdefs.WithStack(err)
 		}
 	}
 	entities := types.EntityList{}
 	if err := sqlxCtx.SelectContext(ctx, &entities, sqlxCtx.Rebind(query), args...); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return entities, nil
 }

--- a/internal/database/metadata/sqlutil/group.go
+++ b/internal/database/metadata/sqlutil/group.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
@@ -30,20 +28,20 @@ func UpdateGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata
 	args = append(args, opt.GroupID)
 
 	if len(cond) == 0 {
-		return errors.Errorf("invalid option: nothing to update")
+		return errdefs.Errorf("invalid option: nothing to update")
 	}
 
 	query := fmt.Sprintf("UPDATE feature_group SET %s WHERE id = ?", strings.Join(cond, ","))
 	result, err := sqlxCtx.ExecContext(ctx, sqlxCtx.Rebind(query), args...)
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	if rowsAffected != 1 {
-		return errors.Errorf("failed to update feature group %d: feature group not found", opt.GroupID)
+		return errdefs.Errorf("failed to update feature group %d: feature group not found", opt.GroupID)
 	}
 	return nil
 }
@@ -53,9 +51,9 @@ func GetGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, id int) (*types
 	query := `SELECT * FROM feature_group WHERE id = ?`
 	if err := sqlxCtx.GetContext(ctx, &group, sqlxCtx.Rebind(query), id); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(errors.Errorf("feature group %d not found", id))
+			return nil, errdefs.NotFound(errdefs.Errorf("feature group %d not found", id))
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	entity, err := GetEntity(ctx, sqlxCtx, group.EntityID)
@@ -71,14 +69,14 @@ func GetGroupByName(ctx context.Context, sqlxCtx metadata.SqlxContext, name stri
 	query := `SELECT * FROM feature_group WHERE name = ?`
 	if err := sqlxCtx.GetContext(ctx, &group, sqlxCtx.Rebind(query), name); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(errors.Errorf("feature group %s not found", name))
+			return nil, errdefs.NotFound(errdefs.Errorf("feature group %s not found", name))
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	entity, err := GetEntity(ctx, sqlxCtx, group.EntityID)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	group.Entity = entity
 	return &group, nil
@@ -87,7 +85,7 @@ func GetGroupByName(ctx context.Context, sqlxCtx metadata.SqlxContext, name stri
 func ListGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, entityID *int, groupIDs *[]int) (types.GroupList, error) {
 	cond, args, err := buildListGroupCond(entityID, groupIDs)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	query := `SELECT * FROM feature_group`
@@ -97,7 +95,7 @@ func ListGroup(ctx context.Context, sqlxCtx metadata.SqlxContext, entityID *int,
 	query = fmt.Sprintf("%s ORDER BY id ASC", query)
 	var groups types.GroupList
 	if err := sqlxCtx.SelectContext(ctx, &groups, sqlxCtx.Rebind(query), args...); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	if err := enrichGroups(ctx, sqlxCtx, groups); err != nil {
@@ -120,7 +118,7 @@ func buildListGroupCond(entityID *int, groupIDs *[]int) (string, []interface{}, 
 		}
 		s, inArgs, err := sqlx.In("id IN (?)", *groupIDs)
 		if err != nil {
-			return "", nil, errors.WithStack(err)
+			return "", nil, errdefs.WithStack(err)
 		}
 		cond = append(cond, s)
 		args = append(args, inArgs...)
@@ -132,14 +130,14 @@ func enrichGroups(ctx context.Context, sqlxCtx metadata.SqlxContext, groups type
 	entityIDs := groups.EntityIDs()
 	entities, err := ListEntity(ctx, sqlxCtx, &entityIDs)
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	for _, group := range groups {
 		entity := entities.Find(func(e *types.Entity) bool {
 			return group.EntityID == e.ID
 		})
 		if entity == nil {
-			return errors.Errorf("cannot find entity %d for group %d", group.EntityID, group.ID)
+			return errdefs.Errorf("cannot find entity %d for group %d", group.EntityID, group.ID)
 		}
 		group.Entity = entity
 	}

--- a/internal/database/metadata/sqlutil/revision.go
+++ b/internal/database/metadata/sqlutil/revision.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -32,21 +30,21 @@ func UpdateRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metad
 		return err
 	}
 	if len(cond) == 0 {
-		return errors.Errorf("invliad option: nothing to update")
+		return errdefs.Errorf("invliad option: nothing to update")
 	}
 	args = append(args, opt.RevisionID)
 
 	query := fmt.Sprintf("UPDATE feature_group_revision SET %s WHERE id = ?", strings.Join(cond, ","))
 	result, err := sqlxCtx.ExecContext(ctx, sqlxCtx.Rebind(query), args...)
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	if rowsAffected != 1 {
-		return errors.Errorf("failed to update revision %d: revision not found", opt.RevisionID)
+		return errdefs.Errorf("failed to update revision %d: revision not found", opt.RevisionID)
 	}
 	return nil
 }
@@ -56,9 +54,9 @@ func GetRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, id int) (*ty
 	query := `SELECT * FROM feature_group_revision WHERE id = ?`
 	if err := sqlxCtx.GetContext(ctx, &revision, sqlxCtx.Rebind(query), id); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(errors.Errorf("revision %d not found", id))
+			return nil, errdefs.NotFound(errdefs.Errorf("revision %d not found", id))
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	group, err := GetGroup(ctx, sqlxCtx, revision.GroupID)
@@ -74,9 +72,9 @@ func GetRevisionBy(ctx context.Context, sqlxCtx metadata.SqlxContext, groupID in
 	query := `SELECT * FROM feature_group_revision WHERE group_id = ? AND revision = ?`
 	if err := sqlxCtx.GetContext(ctx, &r, sqlxCtx.Rebind(query), groupID, revision); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, errdefs.NotFound(errors.Errorf("revision not found by group %d and revision %d", groupID, revision))
+			return nil, errdefs.NotFound(errdefs.Errorf("revision not found by group %d and revision %d", groupID, revision))
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	group, err := GetGroup(ctx, sqlxCtx, r.GroupID)
@@ -97,7 +95,7 @@ func ListRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, groupID *in
 	query = fmt.Sprintf("%s ORDER BY id ASC", query)
 	var revisions types.RevisionList
 	if err := sqlxCtx.SelectContext(ctx, &revisions, sqlxCtx.Rebind(query), args...); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	if err := enrichRevisions(ctx, sqlxCtx, revisions); err != nil {
@@ -117,7 +115,7 @@ func enrichRevisions(ctx context.Context, sqlxCtx metadata.SqlxContext, revision
 			return revision.GroupID == g.ID
 		})
 		if group == nil {
-			return errors.Errorf("cannot find group %d for revision %d", revision.GroupID, revision.ID)
+			return errdefs.Errorf("cannot find group %d for revision %d", revision.GroupID, revision.ID)
 		}
 		revision.Group = group
 	}

--- a/internal/database/offline/bigquery/export.go
+++ b/internal/database/offline/bigquery/export.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"google.golang.org/api/iterator"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
@@ -41,7 +41,7 @@ func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.E
 				break
 			}
 			if err != nil {
-				errs <- errors.Errorf("failed at rows.Next, err=%v", err)
+				errs <- errdefs.Errorf("failed at rows.Next, err=%v", err)
 				return
 			}
 			record := make([]interface{}, 0, len(recordMap))

--- a/internal/database/offline/bigquery/join.go
+++ b/internal/database/offline/bigquery/join.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"google.golang.org/api/iterator"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
@@ -32,7 +32,7 @@ func (db *DB) Join(ctx context.Context, opt offline.JoinOpt) (*types.JoinResult,
 func bigqueryQueryResults(ctx context.Context, dbOpt dbutil.DBOpt, query string, header dbutil.ColumnList, dropTableNames []string, backendType types.BackendType) (*types.JoinResult, error) {
 	rows, err := dbOpt.BigQueryDB.Query(query).Read(ctx)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	data := make(chan []interface{})
@@ -52,7 +52,7 @@ func bigqueryQueryResults(ctx context.Context, dbOpt dbutil.DBOpt, query string,
 				break
 			}
 			if err != nil {
-				scanErr = errors.WithStack(err)
+				scanErr = errdefs.WithStack(err)
 				continue
 			}
 			record := make([]interface{}, 0, len(recordMap))
@@ -93,7 +93,7 @@ func dropTemporaryTables(ctx context.Context, db *bigquery.Client, tableNames []
 func dropTable(ctx context.Context, db *bigquery.Client, tableName string) error {
 	query := fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName)
 	_, err := db.Query(query).Read(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 const READ_JOIN_RESULT_QUERY = `

--- a/internal/database/offline/bigquery/store.go
+++ b/internal/database/offline/bigquery/store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -30,7 +30,7 @@ type DB struct {
 func Open(ctx context.Context, opt *types.BigQueryOpt) (*DB, error) {
 	client, err := bigquery.NewClient(ctx, opt.ProjectID, option.WithCredentialsJSON([]byte(opt.Credentials)))
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return &DB{
 		Client:    client,
@@ -41,14 +41,14 @@ func Open(ctx context.Context, opt *types.BigQueryOpt) (*DB, error) {
 func (db *DB) Ping(ctx context.Context) error {
 	q := db.Client.Query("SELECT 1")
 	_, err := q.Read(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) TableSchema(ctx context.Context, tableName string) (*types.DataTableSchema, error) {
 	q := fmt.Sprintf(`SELECT column_name, data_type FROM %s.INFORMATION_SCHEMA.COLUMNS WHERE table_name = "%s"`, db.datasetID, tableName)
 	rows, err := db.Query(q).Read(ctx)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	var schema types.DataTableSchema
 	for {
@@ -58,7 +58,7 @@ func (db *DB) TableSchema(ctx context.Context, tableName string) (*types.DataTab
 			break
 		}
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errdefs.WithStack(err)
 		}
 		valueType, err := dbutil.ValueType(Backend, cast.ToString(recordMap["data_type"]))
 		if err != nil {
@@ -79,13 +79,13 @@ func (db *DB) Snapshot(ctx context.Context, opt offline.SnapshotOpt) error {
 		BigQueryDB: db.Client,
 		DatasetID:  &db.datasetID,
 	}
-	return errors.WithStack(sqlutil.Snapshot(ctx, dbOpt, opt))
+	return errdefs.WithStack(sqlutil.Snapshot(ctx, dbOpt, opt))
 }
 
 func (db *DB) CreateTable(ctx context.Context, opt offline.CreateTableOpt) error {
 	schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, opt.IsCDC, opt.Features, nil, Backend)
 	if _, err := db.Client.Query(schema).Run(ctx); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	return nil
 }

--- a/internal/database/offline/mysql/store.go
+++ b/internal/database/offline/mysql/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -25,7 +25,7 @@ type DB struct {
 
 func (db *DB) Ping(ctx context.Context) error {
 	err := db.PingContext(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func Open(option *types.MySQLOpt) (*DB, error) {

--- a/internal/database/offline/postgres/store.go
+++ b/internal/database/offline/postgres/store.go
@@ -7,8 +7,8 @@ import (
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
 	"github.com/oom-ai/oomstore/internal/database/offline/sqlutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -45,7 +45,7 @@ func (db *DB) Join(ctx context.Context, opt offline.JoinOpt) (*types.JoinResult,
 func (db *DB) TableSchema(ctx context.Context, tableName string) (*types.DataTableSchema, error) {
 	rows, err := db.QueryxContext(ctx, "select column_name, data_type from information_schema.columns where table_name = $1", tableName)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return sqlutil.SqlxTableSchema(ctx, db, Backend, rows)
 }

--- a/internal/database/offline/postgres/util.go
+++ b/internal/database/offline/postgres/util.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
@@ -16,13 +16,13 @@ import (
 func loadDataFromSource(tx *sqlx.Tx, ctx context.Context, source *offline.CSVSource, tableName string, header []string, features types.FeatureList) error {
 	stmt, err := tx.PreparexContext(ctx, pq.CopyIn(tableName, header...))
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	defer stmt.Close()
 
 	for {
 		record, err := dbutil.ReadLine(source.Reader, source.Delimiter, features, Backend)
-		if errors.Cause(err) == io.EOF {
+		if errdefs.Cause(err) == io.EOF {
 			break
 		}
 		if err != nil {
@@ -32,10 +32,10 @@ func loadDataFromSource(tx *sqlx.Tx, ctx context.Context, source *offline.CSVSou
 			continue
 		}
 		if _, err := stmt.ExecContext(ctx, record...); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 	}
 
 	_, err = stmt.ExecContext(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/offline/redshift/store.go
+++ b/internal/database/offline/redshift/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -25,7 +25,7 @@ type DB struct {
 
 func (db *DB) Ping(ctx context.Context) error {
 	err := db.PingContext(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func Open(option *types.RedshiftOpt) (*DB, error) {
@@ -48,7 +48,7 @@ func (db *DB) Join(ctx context.Context, opt offline.JoinOpt) (*types.JoinResult,
 func (db *DB) TableSchema(ctx context.Context, tableName string) (*types.DataTableSchema, error) {
 	rows, err := db.QueryxContext(ctx, "select column_name, data_type from information_schema.columns where table_name = $1", tableName)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return sqlutil.SqlxTableSchema(ctx, db, Backend, rows)
 }

--- a/internal/database/offline/snowflake/store.go
+++ b/internal/database/offline/snowflake/store.go
@@ -7,8 +7,8 @@ import (
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
 	"github.com/oom-ai/oomstore/internal/database/offline/sqlutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 	"github.com/snowflakedb/gosnowflake"
 )
 
@@ -25,7 +25,7 @@ type DB struct {
 
 func (db *DB) Ping(ctx context.Context) error {
 	err := db.PingContext(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func Open(opt *types.SnowflakeOpt) (*DB, error) {
@@ -36,12 +36,12 @@ func Open(opt *types.SnowflakeOpt) (*DB, error) {
 		Database: opt.Database,
 	})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	db, err := sqlx.Open("snowflake", dsn)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	return &DB{DB: db}, nil
@@ -62,7 +62,7 @@ func (db *DB) Join(ctx context.Context, opt offline.JoinOpt) (*types.JoinResult,
 func (db *DB) TableSchema(ctx context.Context, tableName string) (*types.DataTableSchema, error) {
 	rows, err := db.QueryxContext(ctx, "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = ?", tableName)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return sqlutil.SqlxTableSchema(ctx, db, types.BackendSnowflake, rows)
 }

--- a/internal/database/offline/sqlite/store.go
+++ b/internal/database/offline/sqlite/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -25,12 +25,12 @@ type DB struct {
 
 func (db *DB) Ping(ctx context.Context) error {
 	err := db.PingContext(ctx)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func Open(option *types.SQLiteOpt) (*DB, error) {
 	db, err := dbutil.OpenSQLite(option.DBFile)
-	return &DB{db}, errors.WithStack(err)
+	return &DB{db}, errdefs.WithStack(err)
 }
 
 func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) {
@@ -56,7 +56,7 @@ func (db *DB) TableSchema(ctx context.Context, tableName string) (*types.DataTab
 `
 	rows, err := db.QueryxContext(ctx, query, tableName)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return sqlutil.SqlxTableSchema(ctx, db, types.BackendSQLite, rows)
 }

--- a/internal/database/offline/sqlutil/create_table.go
+++ b/internal/database/offline/sqlutil/create_table.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -16,19 +16,19 @@ func CreateTable(ctx context.Context, db *sqlx.DB, opt offline.CreateTableOpt, b
 		// Create index (entity_key, unix_milli) on cdc table
 		schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, true, opt.Features, nil, backend)
 		if _, err := db.ExecContext(ctx, schema); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 		indexFields := []string{opt.Entity.Name, "unix_milli"}
 		indexDDL := dbutil.BuildIndexDDL(opt.TableName, "idx", indexFields, backend)
 		if _, err := db.ExecContext(ctx, indexDDL); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 	} else {
 		// Create primary key (entity_key) on snapshot table
 		pkFields := []string{opt.Entity.Name}
 		schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, false, opt.Features, pkFields, backend)
 		if _, err := db.ExecContext(ctx, schema); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 	}
 	return nil

--- a/internal/database/offline/sqlutil/export.go
+++ b/internal/database/offline/sqlutil/export.go
@@ -7,8 +7,8 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
 
@@ -31,20 +31,20 @@ func Export(ctx context.Context, db *sqlx.DB, opt offline.ExportOpt, backend typ
 		defer close(errs)
 		stmt, err := db.Preparex(db.Rebind(query))
 		if err != nil {
-			errs <- errors.WithStack(err)
+			errs <- errdefs.WithStack(err)
 			return
 		}
 		defer stmt.Close()
 		rows, err := stmt.Queryx(args...)
 		if err != nil {
-			errs <- errors.WithStack(err)
+			errs <- errdefs.WithStack(err)
 			return
 		}
 		defer rows.Close()
 		for rows.Next() {
 			record, err := rows.SliceScan()
 			if err != nil {
-				errs <- errors.Errorf("failed at rows.SliceScan, err=%v", err)
+				errs <- errdefs.Errorf("failed at rows.SliceScan, err=%v", err)
 				return
 			}
 			record[0] = cast.ToString(record[0])

--- a/internal/database/offline/sqlutil/export.go
+++ b/internal/database/offline/sqlutil/export.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/spf13/cast"
+
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/spf13/cast"
 )
 
 func Export(ctx context.Context, db *sqlx.DB, opt offline.ExportOpt, backend types.BackendType) (<-chan types.ExportRecord, <-chan error) {
@@ -22,7 +23,7 @@ func Export(ctx context.Context, db *sqlx.DB, opt offline.ExportOpt, backend typ
 	if err != nil {
 		defer close(stream)
 		defer close(errs)
-		errs <- errors.WithStack(err)
+		errs <- errdefs.WithStack(err)
 		return stream, errs
 	}
 
@@ -97,7 +98,7 @@ func buildExportStreamQuery(opt offline.ExportOpt, backend types.BackendType) (s
 		Backend:               backend,
 	})
 	if err != nil {
-		return "", nil, errors.WithStack(err)
+		return "", nil, errdefs.WithStack(err)
 	}
 	if opt.Limit != nil {
 		query += fmt.Sprintf(" LIMIT %d", *opt.Limit)

--- a/internal/database/offline/sqlutil/import.go
+++ b/internal/database/offline/sqlutil/import.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
@@ -25,7 +25,7 @@ func Import(ctx context.Context, db *sqlx.DB, opt offline.ImportOpt, loadData Lo
 		schema := dbutil.BuildTableSchema(opt.SnapshotTableName, opt.Entity, false, opt.Features, pkFields, backendType)
 		_, err := tx.ExecContext(ctx, schema)
 		if err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 
 		// populate the data table

--- a/internal/database/offline/sqlutil/join.go
+++ b/internal/database/offline/sqlutil/join.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -266,7 +266,7 @@ func sqlxQueryResults(ctx context.Context, dbOpt dbutil.DBOpt, query string, hea
 	defer stmt.Close()
 	rows, err := stmt.Queryx()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	data := make(chan []interface{})
@@ -282,7 +282,7 @@ func sqlxQueryResults(ctx context.Context, dbOpt dbutil.DBOpt, query string, hea
 		for rows.Next() {
 			record, err := rows.SliceScan()
 			if err != nil {
-				scanErr = errors.WithStack(err)
+				scanErr = errdefs.WithStack(err)
 				continue
 			}
 			deserializedRecord := make([]interface{}, 0, len(record))

--- a/internal/database/offline/sqlutil/join_helper.go
+++ b/internal/database/offline/sqlutil/join_helper.go
@@ -8,7 +8,7 @@ import (
 	"text/template"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -239,7 +239,7 @@ func dropTemporaryTables(ctx context.Context, db *sqlx.DB, tableNames []string) 
 func dropTable(ctx context.Context, db *sqlx.DB, tableName string) error {
 	query := fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, tableName)
 	_, err := db.ExecContext(ctx, query)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func supportIndex(backendType types.BackendType) bool {
@@ -277,7 +277,7 @@ func buildReadJoinResultQuery(query string, params readJoinResultQueryParams) (s
 
 	buf := bytes.NewBuffer(nil)
 	if err := t.Execute(buf, params); err != nil {
-		return "", errors.WithStack(err)
+		return "", errdefs.WithStack(err)
 	}
 	return buf.String(), nil
 }
@@ -311,7 +311,7 @@ func buildJoinQuery(params joinQueryParams) (string, error) {
 
 	buf := bytes.NewBuffer(nil)
 	if err := t.Execute(buf, params); err != nil {
-		return "", errors.WithStack(err)
+		return "", errdefs.WithStack(err)
 	}
 	return buf.String(), nil
 }
@@ -359,7 +359,7 @@ func buildCdcJoinQuery(params cdcJoinQueryParams) (string, error) {
 
 	buf := bytes.NewBuffer(nil)
 	if err := t.Execute(buf, params); err != nil {
-		return "", errors.WithStack(err)
+		return "", errdefs.WithStack(err)
 	}
 	return buf.String(), nil
 }

--- a/internal/database/offline/sqlutil/push.go
+++ b/internal/database/offline/sqlutil/push.go
@@ -3,8 +3,6 @@ package sqlutil
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -24,7 +22,7 @@ func Push(ctx context.Context, dbOpt dbutil.DBOpt, pushOpt offline.PushOpt) erro
 
 	err := dbutil.InsertRecordsToTable(ctx, dbOpt, tableName, rows, columns)
 	if err != nil && dbutil.IsTableNotFoundError(err, dbOpt.Backend) {
-		return errdefs.NotFound(errors.WithStack(err))
+		return errdefs.NotFound(errdefs.WithStack(err))
 	}
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/offline/sqlutil/snapshot.go
+++ b/internal/database/offline/sqlutil/snapshot.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -71,7 +71,7 @@ func Snapshot(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.SnapshotOpt) 
 
 	schema := dbutil.BuildTableSchema(currSnapshotTableName, opt.Group.Entity, false, opt.Features, []string{opt.Group.Entity.Name}, dbOpt.Backend)
 	if err := dbOpt.ExecContext(ctx, schema, nil); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	query, err := buildSnapshotQuery(snapshotQueryParams{
 		EntityName:            opt.Group.Entity.Name,
@@ -86,7 +86,7 @@ func Snapshot(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.SnapshotOpt) 
 		return err
 	}
 	if err = dbOpt.ExecContext(ctx, query, nil); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	return nil
@@ -127,7 +127,7 @@ func buildSnapshotQuery(params snapshotQueryParams) (string, error) {
 
 	buf := bytes.NewBuffer(nil)
 	if err := t.Execute(buf, params); err != nil {
-		return "", errors.WithStack(err)
+		return "", errdefs.WithStack(err)
 	}
 	return buf.String(), nil
 }

--- a/internal/database/offline/sqlutil/table_schema.go
+++ b/internal/database/offline/sqlutil/table_schema.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -19,7 +19,7 @@ func SqlxTableSchema(ctx context.Context, store offline.Store, backend types.Bac
 	for rows.Next() {
 		var fieldName, dbValueType string
 		if err := rows.Scan(&fieldName, &dbValueType); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errdefs.WithStack(err)
 		}
 		valueType, err := dbutil.ValueType(backend, dbValueType)
 		if err != nil {
@@ -31,7 +31,7 @@ func SqlxTableSchema(ctx context.Context, store offline.Store, backend types.Bac
 		})
 	}
 	if len(schema.Fields) == 0 {
-		return nil, errors.Errorf("table not found")
+		return nil, errdefs.Errorf("table not found")
 	}
 	return &schema, nil
 }

--- a/internal/database/online/cassandra/get.go
+++ b/internal/database/online/cassandra/get.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/gocql/gocql"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -33,7 +33,7 @@ func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error)
 		if err == gocql.ErrNotFound || isTableNotFoundError(err, tableName) {
 			return scan, nil
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	rs := make(map[string]interface{}, len(scan))
@@ -73,7 +73,7 @@ func (db *DB) MultiGet(ctx context.Context, opt online.MultiGetOpt) (map[string]
 		if err == gocql.ErrNotFound || isTableNotFoundError(err, tableName) {
 			return rs, nil
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	for _, s := range scan {

--- a/internal/database/online/cassandra/import.go
+++ b/internal/database/online/cassandra/import.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/gocql/gocql"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -21,7 +21,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 
 	// create table
 	if err := db.Query(table).Exec(); err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	var (
@@ -30,19 +30,19 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 	)
 	for record := range opt.ExportStream {
 		if len(record) != len(opt.Features)+1 {
-			return errors.Errorf("field count not matched, expected %d, got %d", len(opt.Features)+1, len(record))
+			return errdefs.Errorf("field count not matched, expected %d, got %d", len(opt.Features)+1, len(record))
 		}
 
 		if batch.Size() != BatchSize {
 			batch.Query(insertStmt, record...)
 		} else {
 			if err := db.ExecuteBatch(batch); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 			batch = db.NewBatch(gocql.LoggedBatch)
 		}
 	}
-	return errors.WithStack(db.ExecuteBatch(batch))
+	return errdefs.WithStack(db.ExecuteBatch(batch))
 }
 
 func buildInsertStatement(tableName string, columns []string) string {

--- a/internal/database/online/cassandra/purge.go
+++ b/internal/database/online/cassandra/purge.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online/sqlutil"
 )
@@ -12,5 +12,5 @@ import (
 func (db *DB) Purge(ctx context.Context, revisionID int) error {
 	err := db.Query(fmt.Sprintf("DROP TABLE IF EXISTS %s", sqlutil.OnlineBatchTableName(revisionID))).
 		WithContext(ctx).Exec()
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/cassandra/store.go
+++ b/internal/database/online/cassandra/store.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -46,7 +46,7 @@ func Open(option *types.CassandraOpt) (*DB, error) {
 
 	session, err := cluster.CreateSession()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return &DB{Session: session}, nil
 }

--- a/internal/database/online/cassandra/stream.go
+++ b/internal/database/online/cassandra/stream.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pingcap/errors"
-
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/internal/database/online/sqlutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
 func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTableOpt) error {
@@ -31,7 +30,7 @@ func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTa
 	sql := fmt.Sprintf("ALTER TABLE %s ADD %s %s", tableName, opt.Feature.Name, dbValueType)
 
 	err = db.Query(sql).WithContext(ctx).Exec()
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
@@ -47,5 +46,5 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 	)
 
 	err := db.Query(query, cond.InsertValues...).WithContext(ctx).Exec()
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/dynamodb/import.go
+++ b/internal/database/online/dynamodb/import.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/internal/database/online/sqlutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	oomTypes "github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -42,7 +42,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 		},
 	})
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	// Step 2: import items to the table
@@ -90,7 +90,7 @@ func buildItem(record oomTypes.ExportRecord, opt online.ImportOpt) (map[string]t
 	item := make(map[string]types.AttributeValue)
 	entityKeyValue, err := attributevalue.Marshal(record.EntityKey())
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	item[opt.Entity.Name] = entityKeyValue
 
@@ -101,7 +101,7 @@ func buildItem(record oomTypes.ExportRecord, opt online.ImportOpt) (map[string]t
 		}
 		attributeValue, err := attributevalue.Marshal(value)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errdefs.WithStack(err)
 		}
 		item[feature.Name] = attributeValue
 	}

--- a/internal/database/online/dynamodb/purge.go
+++ b/internal/database/online/dynamodb/purge.go
@@ -3,7 +3,7 @@ package dynamodb
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -15,5 +15,5 @@ func (db *DB) Purge(ctx context.Context, revisionID int) error {
 	_, err := db.DeleteTable(ctx, &dynamodb.DeleteTableInput{
 		TableName: aws.String(tableName),
 	})
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/dynamodb/store.go
+++ b/internal/database/online/dynamodb/store.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -40,7 +40,7 @@ func Open(opt *types.DynamoDBOpt) (*DB, error) {
 		}),
 	)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	return &DB{dynamodb.NewFromConfig(cfg)}, nil
@@ -48,7 +48,7 @@ func Open(opt *types.DynamoDBOpt) (*DB, error) {
 
 func (db *DB) Ping(ctx context.Context) error {
 	_, err := db.ListTables(ctx, nil)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 // dynamodb is serverless so Close won't do anything

--- a/internal/database/online/dynamodb/stream.go
+++ b/internal/database/online/dynamodb/stream.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/internal/database/online/sqlutil"
@@ -42,7 +42,7 @@ func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTa
 			WriteCapacityUnits: aws.Int64(10),
 		},
 	})
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
@@ -53,7 +53,7 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 
 	entityKeyValue, err := attributevalue.Marshal(opt.EntityKey)
 	if err != nil {
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 	item[opt.Entity.Name] = entityKeyValue
 
@@ -64,7 +64,7 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 		}
 		attributevalue, err := attributevalue.Marshal(value)
 		if err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 		item[feature.Name] = attributevalue
 	}
@@ -73,5 +73,5 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 		TableName: &tableName,
 		Item:      item,
 	})
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/mysql/store.go
+++ b/internal/database/online/mysql/store.go
@@ -6,7 +6,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -30,7 +30,7 @@ func Open(opt *types.MySQLOpt) (*DB, error) {
 }
 
 func (db *DB) Ping(ctx context.Context) error {
-	return errors.WithStack(db.PingContext(ctx))
+	return errdefs.WithStack(db.PingContext(ctx))
 }
 
 func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error) {
@@ -62,7 +62,7 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 	)
 
 	_, err := db.ExecContext(ctx, db.Rebind(query), append(cond.InsertValues, cond.UpdateValues...)...)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTableOpt) error {

--- a/internal/database/online/postgres/store.go
+++ b/internal/database/online/postgres/store.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -30,7 +30,7 @@ func Open(opt *types.PostgresOpt) (*DB, error) {
 }
 
 func (db *DB) Ping(ctx context.Context) error {
-	return errors.WithStack(db.PingContext(ctx))
+	return errdefs.WithStack(db.PingContext(ctx))
 }
 
 func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error) {
@@ -63,7 +63,7 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 	)
 
 	_, err := db.ExecContext(ctx, db.Rebind(query), append(cond.InsertValues, cond.UpdateValues...)...)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTableOpt) error {

--- a/internal/database/online/redis/get.go
+++ b/internal/database/online/redis/get.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -36,7 +36,7 @@ func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error)
 
 	values, err := db.HMGet(ctx, key, featureIDs...).Result()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	rowMap := make(dbutil.RowMap)
@@ -65,7 +65,7 @@ func (db *DB) MultiGet(ctx context.Context, opt online.MultiGetOpt) (map[string]
 			Features:   opt.Features,
 		})
 		if err != nil {
-			return res, errors.WithStack(err)
+			return res, errdefs.WithStack(err)
 		}
 		if len(rowMap) > 0 {
 			res[entityKey] = rowMap

--- a/internal/database/online/redis/import.go
+++ b/internal/database/online/redis/import.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 )
@@ -49,14 +49,14 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 		seq++
 		if seq%PipelineBatchSize == 0 {
 			if _, err := pipe.Exec(ctx); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 	}
 
 	if seq%PipelineBatchSize != 0 {
 		if _, err := pipe.Exec(ctx); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 	}
 	if opt.ExportError != nil {

--- a/internal/database/online/redis/purge.go
+++ b/internal/database/online/redis/purge.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
 func (db *DB) Purge(ctx context.Context, revisionID int) error {
@@ -20,12 +20,12 @@ func (db *DB) Purge(ctx context.Context, revisionID int) error {
 	for {
 		keys, cursor, err = db.Scan(ctx, cursor, pattern, PipelineBatchSize).Result()
 		if err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 
 		if len(keys) > 0 {
 			if _, err = db.Del(ctx, keys...).Result(); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 		}
 

--- a/internal/database/online/sqlite/store.go
+++ b/internal/database/online/sqlite/store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -29,7 +29,7 @@ func Open(opt *types.SQLiteOpt) (*DB, error) {
 }
 
 func (db *DB) Ping(ctx context.Context) error {
-	return errors.WithStack(db.PingContext(ctx))
+	return errdefs.WithStack(db.PingContext(ctx))
 }
 
 func (db *DB) Get(ctx context.Context, opt online.GetOpt) (dbutil.RowMap, error) {
@@ -60,7 +60,7 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 	)
 
 	_, err := db.ExecContext(ctx, db.Rebind(query), cond.InsertValues...)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTableOpt) error {

--- a/internal/database/online/sqlutil/get.go
+++ b/internal/database/online/sqlutil/get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -30,7 +30,7 @@ func Get(ctx context.Context, db *sqlx.DB, opt online.GetOpt, backend types.Back
 		if err == sql.ErrNoRows || dbutil.IsTableNotFoundError(err, backend) {
 			return make(dbutil.RowMap), nil
 		}
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	rs, err := deserializeIntoRowMap(record, opt.Features, backend)
@@ -54,12 +54,12 @@ func MultiGet(ctx context.Context, db *sqlx.DB, opt online.MultiGetOpt, backend 
 	query := fmt.Sprintf(`SELECT %s, %s FROM %s WHERE %s in (?);`, qt(opt.Entity.Name), qt(featureNames...), qt(tableName), qt(opt.Entity.Name))
 	sql, args, err := sqlx.In(query, opt.EntityKeys)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	rows, err := db.QueryxContext(ctx, db.Rebind(sql), args...)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	defer rows.Close()
 
@@ -71,11 +71,11 @@ func getFeatureValueMapFromRows(rows *sqlx.Rows, features types.FeatureList, bac
 	for rows.Next() {
 		record, err := rows.SliceScan()
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errdefs.WithStack(err)
 		}
 		entityKey, err := dbutil.DeserializeByValueType(record[0], types.String, backend)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, errdefs.WithStack(err)
 		}
 		values := record[1:]
 		rowMap, err := deserializeIntoRowMap(values, features, backend)

--- a/internal/database/online/sqlutil/import.go
+++ b/internal/database/online/sqlutil/import.go
@@ -6,8 +6,8 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 const importBatchSize = 10
@@ -20,14 +20,14 @@ func Import(ctx context.Context, db *sqlx.DB, opt online.ImportOpt, backend type
 		schema := dbutil.BuildTableSchema(tableName, opt.Entity, false, opt.Features, []string{opt.Entity.Name}, backend)
 		_, err := tx.ExecContext(ctx, schema)
 		if err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 
 		// populate the data table
 		records := make([]interface{}, 0, importBatchSize)
 		for record := range opt.ExportStream {
 			if len(record) != len(opt.Features)+1 {
-				return errors.Errorf("field count not matched, expected %d, got %d", len(opt.Features)+1, len(record))
+				return errdefs.Errorf("field count not matched, expected %d, got %d", len(opt.Features)+1, len(record))
 			}
 			records = append(records, record)
 

--- a/internal/database/online/sqlutil/purge.go
+++ b/internal/database/online/sqlutil/purge.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -15,5 +15,5 @@ func Purge(ctx context.Context, db *sqlx.DB, revisionID int, backend types.Backe
 	qt := dbutil.QuoteFn(backend)
 	query := fmt.Sprintf(`DROP TABLE IF EXISTS %s;`, qt(OnlineBatchTableName(revisionID)))
 	_, err := db.ExecContext(ctx, query)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/sqlutil/util.go
+++ b/internal/database/online/sqlutil/util.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/jmoiron/sqlx"
+
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -31,7 +30,7 @@ func CreateStreamTableSchema(ctx context.Context, tableName string, entity *type
 	case types.BackendPostgres, types.BackendCassandra, types.BackendSQLite:
 		entityFormat = fmt.Sprintf(`"%s" TEXT PRIMARY KEY`, entity.Name)
 	default:
-		return "", errdefs.InvalidAttribute(errors.Errorf("backend %s not support", backend))
+		return "", errdefs.InvalidAttribute(errdefs.Errorf("backend %s not support", backend))
 	}
 
 	schema := fmt.Sprintf("CREATE TABLE %s ( %s )", tableName, entityFormat)
@@ -47,7 +46,7 @@ func SqlxPrapareStreamTable(ctx context.Context, db *sqlx.DB, opt online.Prepare
 			return err
 		}
 		_, err = db.ExecContext(ctx, schema)
-		return errors.WithStack(err)
+		return errdefs.WithStack(err)
 	}
 
 	dbValueType, err := dbutil.DBValueType(backend, opt.Feature.ValueType)
@@ -57,5 +56,5 @@ func SqlxPrapareStreamTable(ctx context.Context, db *sqlx.DB, opt online.Prepare
 
 	sql := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", tableName, opt.Feature.Name, dbValueType)
 	_, err = db.ExecContext(ctx, sql)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/tikv/get.go
+++ b/internal/database/online/tikv/get.go
@@ -3,7 +3,7 @@ package tikv
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -85,7 +85,7 @@ func (db *DB) MultiGet(ctx context.Context, opt online.MultiGetOpt) (map[string]
 	// Result order is the same as input order
 	batchGetResult, err := db.BatchGet(ctx, keys)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 
 	// What we need to align with the result

--- a/internal/database/online/tikv/import.go
+++ b/internal/database/online/tikv/import.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 )
@@ -34,7 +34,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 
 	for record := range opt.ExportStream {
 		if len(record) != len(opt.Features)+1 {
-			return errors.Errorf("field count not matched, expected %d, got %d", len(opt.Features)+1, len(record))
+			return errdefs.Errorf("field count not matched, expected %d, got %d", len(opt.Features)+1, len(record))
 		}
 
 		entityKey, featureValues := record[0], record[1:]
@@ -63,7 +63,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 		if seq%BatchSize == 0 {
 			// We don't expire keys using TTL
 			if err = db.BatchPut(ctx, putKeys, putVals, []uint64{}); err != nil {
-				return errors.WithStack(err)
+				return errdefs.WithStack(err)
 			}
 			// Reset the slices
 			putKeys, putVals = nil, nil
@@ -73,7 +73,7 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 	if seq%BatchSize != 0 {
 		// We don't expire keys using TTL
 		if err := db.BatchPut(ctx, putKeys, putVals, []uint64{}); err != nil {
-			return errors.WithStack(err)
+			return errdefs.WithStack(err)
 		}
 	}
 

--- a/internal/database/online/tikv/purge.go
+++ b/internal/database/online/tikv/purge.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online/kvutil"
 )
@@ -19,5 +19,5 @@ func (db *DB) Purge(ctx context.Context, revisionID int) error {
 	endKey := append([]byte(kvutil.KeyPrefixForBatchFeature+serializedRevisionID), byte(keyDelimiter+1))
 
 	err = db.DeleteRange(ctx, startKey, endKey)
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/tikv/push.go
+++ b/internal/database/online/tikv/push.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/online"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
 func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
@@ -44,5 +44,5 @@ func (db *DB) Push(ctx context.Context, opt online.PushOpt) error {
 
 	// We don't expire keys using TTL
 	err = db.BatchPut(ctx, putKeys, putVals, []uint64{})
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }

--- a/internal/database/online/tikv/store.go
+++ b/internal/database/online/tikv/store.go
@@ -3,8 +3,8 @@ package tikv
 import (
 	"context"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/pingcap/log"
-	"github.com/pkg/errors"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/rawkv"
 	"go.uber.org/zap/zapcore"
@@ -29,7 +29,7 @@ type DB struct {
 func Open(opt *types.TiKVOpt) (*DB, error) {
 	db, err := rawkv.NewClient(context.Background(), opt.PdAddrs, config.DefaultConfig().Security)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errdefs.WithStack(err)
 	}
 	return &DB{db}, nil
 }
@@ -40,7 +40,7 @@ func (db *DB) Close() error {
 
 func (db *DB) Ping(ctx context.Context) error {
 	_, err := db.Client.Get(ctx, []byte(""))
-	return errors.WithStack(err)
+	return errdefs.WithStack(err)
 }
 
 func (db *DB) PrepareStreamTable(ctx context.Context, opt online.PrepareStreamTableOpt) error {

--- a/oomagent/codegen/oomagent.pb.go
+++ b/oomagent/codegen/oomagent.pb.go
@@ -7,12 +7,13 @@
 package codegen
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/oomagent/codegen/oomagent_grpc.pb.go
+++ b/oomagent/codegen/oomagent_grpc.pb.go
@@ -4,6 +4,7 @@ package codegen
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/oomagent/server.go
+++ b/oomagent/server.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"time"
 
-	"github.com/pkg/errors"
 	code "google.golang.org/genproto/googleapis/rpc/code"
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/oom-ai/oomstore/oomagent/codegen"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -258,7 +258,7 @@ func (s *server) ChannelJoin(stream codegen.OomAgent_ChannelJoinServer) error {
 			break
 		}
 		if req.GetEntityRow() == nil {
-			globalErr = errors.Errorf("cannot process nil entity row")
+			globalErr = errdefs.Errorf("cannot process nil entity row")
 			break
 		}
 		entityRows <- types.EntityRow{
@@ -423,7 +423,7 @@ func convertInterfaceToValue(i interface{}) (*codegen.Value, error) {
 			},
 		}, nil
 	default:
-		return nil, errors.Errorf("unsupported value type %T", i)
+		return nil, errdefs.Errorf("unsupported value type %T", i)
 	}
 }
 
@@ -432,7 +432,7 @@ func convertJoinedRow(row []interface{}) ([]*codegen.Value, error) {
 	for _, value := range row {
 		v, err := convertInterfaceToValue(value)
 		if err != nil {
-			return nil, errors.Errorf("failed to marshal %v", value)
+			return nil, errdefs.Errorf("failed to marshal %v", value)
 		}
 		res = append(res, v)
 	}

--- a/oomagent/test/test.sh
+++ b/oomagent/test/test.sh
@@ -6,6 +6,7 @@ echo '=== VERSION INFO ==='
 oomcli --version
 echo
 
+export DEBUG='enable'
 for test_file in test_*.sh; do
     echo "=== RUN $test_file ==="
     "./$test_file"

--- a/oomcli/cmd/edit.go
+++ b/oomcli/cmd/edit.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cobra"
 
 	"github.com/oom-ai/oomstore/pkg/oomstore"
@@ -44,7 +44,7 @@ func checkCommandExist(cmd string) bool {
 
 func editFileByExternalEditor(ctx context.Context, fileName string) error {
 	if !checkCommandExist(editor) {
-		return errors.Errorf("%s not found", editor)
+		return errdefs.Errorf("%s not found", editor)
 	}
 
 	cmd := exec.CommandContext(ctx, editor, fileName)

--- a/oomcli/cmd/export_helper.go
+++ b/oomcli/cmd/export_helper.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 
 	"github.com/oom-ai/oomstore/pkg/oomstore"
@@ -32,7 +32,7 @@ func printExportResult(exportResult *types.ExportResult, output string) error {
 	case ASCIITable:
 		return printExportResultInASCIITable(exportResult)
 	default:
-		return errors.Errorf("unsupported output format %s", output)
+		return errdefs.Errorf("unsupported output format %s", output)
 	}
 }
 

--- a/oomcli/cmd/get_meta_feature.go
+++ b/oomcli/cmd/get_meta_feature.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cobra"
 
 	"github.com/oom-ai/oomstore/pkg/oomstore"
@@ -62,7 +62,7 @@ func queryFeatures(ctx context.Context, oomStore *oomstore.OomStore, opt types.L
 	}
 
 	if opt.FeatureFullNames != nil && len(features) == 0 {
-		return nil, errors.Errorf("feature '%s' not found", (*opt.FeatureFullNames)[0])
+		return nil, errdefs.Errorf("feature '%s' not found", (*opt.FeatureFullNames)[0])
 	}
 
 	return features, nil

--- a/oomcli/cmd/get_meta_group.go
+++ b/oomcli/cmd/get_meta_group.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +67,7 @@ func queryGroups(ctx context.Context, oomStore *oomstore.OomStore, entityName, g
 		}
 
 		if entityName != nil && group.Entity.Name != *entityName {
-			return nil, errors.Errorf("group '%s' entityName is '%s' not '%s'", *groupName, group.Entity.Name, *entityName)
+			return nil, errdefs.Errorf("group '%s' entityName is '%s' not '%s'", *groupName, group.Entity.Name, *entityName)
 		}
 		return types.GroupList{group}, err
 	}

--- a/oomcli/cmd/get_online.go
+++ b/oomcli/cmd/get_online.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
@@ -53,7 +53,7 @@ func printOnlineFeatures(featureValues *types.FeatureValues, output string) erro
 	case ASCIITable:
 		return printOnlineFeaturesInASCIITable(featureValues)
 	default:
-		return errors.Errorf("unsupported output format %s", output)
+		return errdefs.Errorf("unsupported output format %s", output)
 	}
 }
 

--- a/oomcli/cmd/join_helper.go
+++ b/oomcli/cmd/join_helper.go
@@ -5,7 +5,7 @@ import (
 	"encoding/csv"
 	"os"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 
 	"github.com/olekukonko/tablewriter"
@@ -47,7 +47,7 @@ func printJoinResult(joinResult *types.JoinResult, output string) error {
 	case ASCIITable:
 		return printJoinResultInASCIITable(joinResult)
 	default:
-		return errors.Errorf("unsupported output format %s", output)
+		return errdefs.Errorf("unsupported output format %s", output)
 	}
 }
 

--- a/oomcli/cmd/serialize.go
+++ b/oomcli/cmd/serialize.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/fatih/structtag"
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 	"gopkg.in/yaml.v3"
 )
@@ -109,7 +109,7 @@ func serializeMetadata(w io.Writer, i interface{}, format string, wide bool) err
 	case Column:
 		return serializeInASCIITable(w, header, records, false)
 	default:
-		return errors.Errorf("unsupported output format %s", format)
+		return errdefs.Errorf("unsupported output format %s", format)
 	}
 }
 

--- a/oomcli/cmd/types.go
+++ b/oomcli/cmd/types.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"time"
 
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 )
 
 type FlattenEntity struct {
@@ -131,7 +131,7 @@ func parseTokenLists(i interface{}) (headerTokens TokenList, dataTokens []TokenL
 			dataTokens = append(dataTokens, tokens)
 		}
 	default:
-		return nil, nil, errors.Errorf("unsupported type %T", i)
+		return nil, nil, errdefs.Errorf("unsupported type %T", i)
 	}
 	headerTokens, err = parseTokens(element)
 	if err != nil {

--- a/oomcli/cmd/util.go
+++ b/oomcli/cmd/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/oom-ai/oomstore/pkg/oomstore"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -43,6 +44,11 @@ func groupsToApplyGroupItems(ctx context.Context, store *oomstore.OomStore, grou
 }
 
 func exitf(format string, a ...interface{}) {
+	if true {
+		format = strings.ReplaceAll(format, "{err}", "%+v")
+	} else {
+		format = strings.ReplaceAll(format, "{err}", "%v")
+	}
 	msg := fmt.Sprintf(format, a...)
 	fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
 	os.Exit(1)

--- a/oomcli/test/test.sh
+++ b/oomcli/test/test.sh
@@ -6,6 +6,7 @@ echo '=== VERSION INFO ==='
 oomcli --version
 echo
 
+export DEBUG='enable'
 for test_file in test_*.sh; do
     echo "=== RUN $test_file ==="
     "./$test_file"

--- a/pkg/errdefs/wrap.go
+++ b/pkg/errdefs/wrap.go
@@ -1,0 +1,38 @@
+// A wrapper around pkg/errors.
+// Prints the error call stack when the environment variable DEBUG is on, otherwise it does not print
+package errdefs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+var debug bool
+
+func init() {
+	v := os.Getenv("DEBUG")
+	if v == "enabled" || v == "1" || v == "true" {
+		debug = true
+	}
+}
+
+func Errorf(format string, args ...interface{}) error {
+	if !debug {
+		return fmt.Errorf(format, args...)
+	}
+	return errors.Errorf(format, args...)
+}
+
+func WithStack(err error) error {
+	if !debug {
+		return err
+	}
+
+	return errors.WithStack(err)
+}
+
+func Cause(err error) error {
+	return errors.Cause(err)
+}

--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 	"gopkg.in/yaml.v3"
 
@@ -275,7 +274,7 @@ func buildApplyStage(ctx context.Context, opt apply.ApplyOpt) (*apply.ApplyStage
 				}
 			}
 		default:
-			return nil, errors.Errorf("invalid kind '%s'", kind)
+			return nil, errdefs.Errorf("invalid kind '%s'", kind)
 		}
 	}
 	return stage, nil
@@ -288,7 +287,7 @@ func parseKind(data map[string]interface{}) (string, error) {
 	if _, ok := data["items"]; ok {
 		return "Items", nil
 	}
-	return "", errors.Errorf("invalid yaml: missing kind or items")
+	return "", errdefs.Errorf("invalid yaml: missing kind or items")
 }
 
 func parseItemsKind(data map[string]interface{}) (string, error) {

--- a/pkg/oomstore/feature.go
+++ b/pkg/oomstore/feature.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/internal/database/online"
@@ -107,7 +107,7 @@ func validateFeatureFullNames(names []string) error {
 	for _, name := range names {
 		nameSlice := strings.Split(name, FeatureFullNameSeparator)
 		if len(nameSlice) != 2 {
-			return errors.Errorf("invalid feature full name %s", name)
+			return errdefs.Errorf("invalid feature full name %s", name)
 		}
 	}
 	return nil

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
@@ -39,7 +39,7 @@ func (s *OomStore) Import(ctx context.Context, opt types.ImportOpt) (int, error)
 	case types.TABLE_LINK:
 		return s.tableLinkImport(ctx, importOpt, opt.TableLinkDataSource)
 	default:
-		return 0, errors.Errorf("unsupported data source: %v", opt.DataSourceType)
+		return 0, errdefs.Errorf("unsupported data source: %v", opt.DataSourceType)
 	}
 }
 
@@ -52,11 +52,11 @@ func (s *OomStore) csvReaderImport(ctx context.Context, opt *importOpt, dataSour
 		return 0, err
 	}
 	if hasDup(cast.ToStringSlice(header)) {
-		return 0, errors.Errorf("csv data source has duplicated columns: %v", header)
+		return 0, errdefs.Errorf("csv data source has duplicated columns: %v", header)
 	}
 	columnNames := append([]string{opt.entity.Name}, opt.features.Names()...)
 	if !stringSliceEqual(cast.ToStringSlice(header), columnNames) {
-		return 0, errors.Errorf("csv header of the data source %v doesn't match the feature group schema %v", header, columnNames)
+		return 0, errdefs.Errorf("csv header of the data source %v doesn't match the feature group schema %v", header, columnNames)
 	}
 
 	newRevisionID, snapshotTableName, err := s.metadata.CreateRevision(ctx, metadata.CreateRevisionOpt{
@@ -110,12 +110,12 @@ func (s *OomStore) tableLinkImport(ctx context.Context, opt *importOpt, dataSour
 		for _, field := range tableSchema.Fields {
 			if field.Name == f.Name {
 				if field.ValueType != f.ValueType {
-					return errors.Errorf("expect value type '%s', got '%s'", f.ValueType, field.ValueType)
+					return errdefs.Errorf("expect value type '%s', got '%s'", f.ValueType, field.ValueType)
 				}
 				return nil
 			}
 		}
-		return errors.Errorf("field '%s' found in target table", f.Name)
+		return errdefs.Errorf("field '%s' found in target table", f.Name)
 	}
 	for _, feature := range opt.features {
 		if err := validate(feature); err != nil {
@@ -187,13 +187,13 @@ func (s *OomStore) parseImportOpt(ctx context.Context, opt types.ImportOpt) (*im
 		return nil, err
 	}
 	if features == nil {
-		err = errors.Errorf("no features under group: %s", opt.GroupName)
+		err = errdefs.Errorf("no features under group: %s", opt.GroupName)
 		return nil, err
 	}
 
 	entity := group.Entity
 	if entity == nil {
-		return nil, errors.Errorf("no entity found by group: %s", opt.GroupName)
+		return nil, errdefs.Errorf("no entity found by group: %s", opt.GroupName)
 	}
 
 	return &importOpt{

--- a/pkg/oomstore/join.go
+++ b/pkg/oomstore/join.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/internal/database/offline"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
 
@@ -46,7 +46,7 @@ func (s *OomStore) ChannelJoin(ctx context.Context, opt types.ChannelJoinOpt) (*
 		return nil, err
 	}
 	if entity == nil {
-		return nil, errors.Errorf("failed to get shared entity")
+		return nil, errdefs.Errorf("failed to get shared entity")
 	}
 
 	featureMap := buildGroupToFeaturesMap(features)
@@ -164,7 +164,7 @@ func GetEntityRowsFromInputFile(inputFilePath string) (<-chan types.EntityRow, [
 				return
 			}
 			if len(line) < 2 {
-				readErr = errors.Errorf("at least 2 values per row, got %d value(s) at row %d", len(line), i)
+				readErr = errdefs.Errorf("at least 2 values per row, got %d value(s) at row %d", len(line), i)
 				return
 			}
 			unixMilli, err := strconv.Atoi(line[1])

--- a/pkg/oomstore/online_query.go
+++ b/pkg/oomstore/online_query.go
@@ -3,7 +3,7 @@ package oomstore
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/metadata"
@@ -77,7 +77,7 @@ func (s *OomStore) OnlineMultiGet(ctx context.Context, opt types.OnlineMultiGetO
 		return nil, err
 	}
 	if entity == nil {
-		return nil, errors.Errorf("failed to get shared entity")
+		return nil, errdefs.Errorf("failed to get shared entity")
 	}
 	featureMap := groupFeaturesByGroupID(features)
 
@@ -148,11 +148,11 @@ func getSharedEntity(features types.FeatureList) (*types.Entity, error) {
 		m[f.Group.EntityID] = f.Group.Entity
 	}
 	if len(m) != 1 {
-		return nil, errors.Errorf("expected 1 entity, got %d entities", len(m))
+		return nil, errdefs.Errorf("expected 1 entity, got %d entities", len(m))
 	}
 
 	for _, entity := range m {
 		return entity, nil
 	}
-	return nil, errors.Errorf("expected 1 entity, got 0")
+	return nil, errdefs.Errorf("expected 1 entity, got 0")
 }

--- a/pkg/oomstore/push.go
+++ b/pkg/oomstore/push.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/online"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
@@ -21,7 +21,7 @@ func (s *OomStore) Push(ctx context.Context, opt types.PushOpt) error {
 	entity := features[0].Entity()
 	group := features[0].Group
 	if !stringSliceEqual(features.Names(), opt.FeatureNames) {
-		return errors.Errorf("FeatureNames %v does not match with group's features %v", opt.FeatureNames, features.Names())
+		return errdefs.Errorf("FeatureNames %v does not match with group's features %v", opt.FeatureNames, features.Names())
 	}
 	values := make([]interface{}, 0, len(features))
 	for _, f := range features {

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 
 	"github.com/oom-ai/oomstore/internal/database/metadata"
 	"github.com/oom-ai/oomstore/internal/database/offline"
@@ -29,7 +29,7 @@ func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
 	group := revision.Group
 	prevOnlineRevisionID := group.OnlineRevisionID
 	if prevOnlineRevisionID != nil && *prevOnlineRevisionID == opt.RevisionID {
-		return errors.Errorf("the specific revision was synced to the online store, won't do it again this time")
+		return errdefs.Errorf("the specific revision was synced to the online store, won't do it again this time")
 	}
 
 	features, err := s.ListFeature(ctx, types.ListFeatureOpt{

--- a/pkg/oomstore/types/apply/apply.go
+++ b/pkg/oomstore/types/apply/apply.go
@@ -3,8 +3,6 @@ package apply
 import (
 	"io"
 
-	"github.com/pkg/errors"
-
 	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
@@ -37,10 +35,10 @@ type Feature struct {
 
 func (f *Feature) Validate() error {
 	if f.Name == "" {
-		return errdefs.InvalidAttribute(errors.Errorf("the name of feature should not be empty"))
+		return errdefs.InvalidAttribute(errdefs.Errorf("the name of feature should not be empty"))
 	}
 	if f.ValueType == "" {
-		return errdefs.InvalidAttribute(errors.Errorf("the value type of feature should not be empty"))
+		return errdefs.InvalidAttribute(errdefs.Errorf("the value type of feature should not be empty"))
 	}
 	return nil
 }
@@ -129,7 +127,7 @@ func FromGroupList(groups types.GroupList, features types.FeatureList) *GroupIte
 
 func (g *Group) Validate() error {
 	if g.Name == "" {
-		return errdefs.InvalidAttribute(errors.Errorf("the name of group should not be empty"))
+		return errdefs.InvalidAttribute(errdefs.Errorf("the name of group should not be empty"))
 	}
 	return nil
 }
@@ -144,7 +142,7 @@ type Entity struct {
 
 func (e *Entity) Validate() error {
 	if e.Name == "" {
-		return errdefs.InvalidAttribute(errors.Errorf("the name of entity should not be empty"))
+		return errdefs.InvalidAttribute(errdefs.Errorf("the name of entity should not be empty"))
 	}
 	return nil
 }

--- a/pkg/oomstore/types/config.go
+++ b/pkg/oomstore/types/config.go
@@ -3,7 +3,7 @@ package types
 import (
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
 type BackendType string
@@ -154,7 +154,7 @@ func (cfg *MetadataStoreConfig) Validate() error {
 		n++
 	}
 	if n != 1 {
-		return errors.Errorf("require exactly one metadata store backend")
+		return errdefs.Errorf("require exactly one metadata store backend")
 	}
 	return nil
 }
@@ -194,7 +194,7 @@ func (cfg *OnlineStoreConfig) Validate() error {
 		n++
 	}
 	if n != 1 {
-		return errors.Errorf("require exactly one online store backend")
+		return errdefs.Errorf("require exactly one online store backend")
 	}
 	return nil
 }
@@ -230,7 +230,7 @@ func (cfg *OfflineStoreConfig) Validate() error {
 		n++
 	}
 	if n != 1 {
-		return errors.Errorf("require exactly one offline store backend")
+		return errdefs.Errorf("require exactly one offline store backend")
 	}
 	return nil
 }

--- a/pkg/oomstore/types/value_type.go
+++ b/pkg/oomstore/types/value_type.go
@@ -3,8 +3,6 @@ package types
 import (
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"github.com/oom-ai/oomstore/pkg/errdefs"
 )
 
@@ -50,7 +48,7 @@ func (v ValueType) Validate() error {
 	if _, ok := allValueTypes[v]; ok {
 		return nil
 	} else {
-		return errdefs.InvalidAttribute(errors.Errorf("Invalid value type: %d", v))
+		return errdefs.InvalidAttribute(errdefs.Errorf("Invalid value type: %d", v))
 	}
 }
 
@@ -58,6 +56,6 @@ func ParseValueType(s string) (ValueType, error) {
 	if v, ok := allValueTypeStrings[s]; ok {
 		return v, nil
 	} else {
-		return Invalid, errdefs.InvalidAttribute(errors.Errorf("Unknown value type: %s", s))
+		return Invalid, errdefs.InvalidAttribute(errdefs.Errorf("Unknown value type: %s", s))
 	}
 }


### PR DESCRIPTION
This PR wraps the functions of the pkg/errors package that we use and uses environment variables `DEBUG` in the wrapped methods to determine whether the error should be printed on the call stack