### PR TITLE
Jinghan/refactor `sqlutil.Export`: adapt with bigquery store

### DIFF
--- a/internal/database/offline/bigquery/store_test.go
+++ b/internal/database/offline/bigquery/store_test.go
@@ -77,7 +77,6 @@ func TestImport(t *testing.T) {
 }
 
 func TestExport(t *testing.T) {
-	t.Skip("skip export test for bigquery until we support exporting stream features")
 	test_impl.TestExport(t, prepareStore, destroyStore(DATASET_ID))
 }
 

--- a/internal/database/offline/sqlutil/export_helper.go
+++ b/internal/database/offline/sqlutil/export_helper.go
@@ -72,6 +72,8 @@ type aggregateQueryParams struct {
 func buildAggregateQuery(params aggregateQueryParams) (string, error) {
 	if params.Backend == types.BackendBigQuery {
 		params.Union = "UNION DISTINCT"
+		params.PrevSnapshotTableName = fmt.Sprintf("%s.%s", *params.DatasetID, params.PrevSnapshotTableName)
+		params.CurrCdcTableName = fmt.Sprintf("%s.%s", *params.DatasetID, params.CurrCdcTableName)
 	} else {
 		params.Union = "UNION"
 	}


### PR DESCRIPTION
This PR does:
- modify `sqlutil.Export`, to make it adapt with bigquery offline store
- use `sqlutil.Export` for bigquery method `Export`

related to #802 