### PR TITLE
refactor: rename Export to ExportBatch

### DIFF
--- a/oomagent/codegen/oomagent.pb.go
+++ b/oomagent/codegen/oomagent.pb.go
@@ -7,13 +7,12 @@
 package codegen
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/oomagent/codegen/oomagent_grpc.pb.go
+++ b/oomagent/codegen/oomagent_grpc.pb.go
@@ -4,7 +4,6 @@ package codegen
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/oomagent/server.go
+++ b/oomagent/server.go
@@ -294,7 +294,7 @@ func (s *server) Join(ctx context.Context, req *codegen.JoinRequest) (*codegen.J
 
 func (s *server) ChannelExport(req *codegen.ChannelExportRequest, stream codegen.OomAgent_ChannelExportServer) error {
 	ctx := context.Background()
-	exportResult, err := s.oomstore.ChannelExport(ctx, types.ChannelExportOpt{
+	exportResult, err := s.oomstore.ChannelExportBatch(ctx, types.ChannelExportBatchOpt{
 		FeatureNames: req.FeatureNames,
 		RevisionID:   int(req.RevisionId),
 		Limit:        req.Limit,
@@ -331,7 +331,7 @@ func (s *server) ChannelExport(req *codegen.ChannelExportRequest, stream codegen
 }
 
 func (s *server) Export(ctx context.Context, req *codegen.ExportRequest) (*codegen.ExportResponse, error) {
-	err := s.oomstore.Export(ctx, types.ExportOpt{
+	err := s.oomstore.ExportBatch(ctx, types.ExportBatchOpt{
 		FeatureNames:   req.FeatureNames,
 		RevisionID:     int(req.RevisionId),
 		Limit:          req.Limit,

--- a/oomcli/cmd/export.go
+++ b/oomcli/cmd/export.go
@@ -8,11 +8,11 @@ import (
 )
 
 var exportOutput *string
-var exportOpt types.ChannelExportOpt
+var exportOpt types.ChannelExportBatchOpt
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
-	Short: "Export historical features in a group",
+	Short: "ExportBatch historical features in a group",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if !cmd.Flags().Changed("limit") {
 			exportOpt.Limit = nil

--- a/oomcli/cmd/export_helper.go
+++ b/oomcli/cmd/export_helper.go
@@ -14,8 +14,8 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-func export(ctx context.Context, store *oomstore.OomStore, opt types.ChannelExportOpt, output string) error {
-	exportResult, err := store.ChannelExport(ctx, opt)
+func export(ctx context.Context, store *oomstore.OomStore, opt types.ChannelExportBatchOpt, output string) error {
+	exportResult, err := store.ChannelExportBatch(ctx, opt)
 	if err != nil {
 		return err
 	}

--- a/pkg/oomstore/export.go
+++ b/pkg/oomstore/export.go
@@ -15,9 +15,9 @@ import (
 )
 
 /*
-ChannelExport exports batch feature values of a particular revision.
+ChannelExportBatch exports batch feature values of a particular revision.
 Usage Example:
-	exportResult, err := store.Export(ctx, opt)
+	exportResult, err := store.ExportBatch(ctx, opt)
 	if err != nil {
 		return err
 	}
@@ -27,7 +27,7 @@ Usage Example:
 	// Attention: call CheckStreamError after consuming exportResult.Data channel
 	return exportResult.CheckStreamError()
 */
-func (s *OomStore) ChannelExport(ctx context.Context, opt types.ChannelExportOpt) (*types.ExportResult, error) {
+func (s *OomStore) ChannelExportBatch(ctx context.Context, opt types.ChannelExportBatchOpt) (*types.ExportResult, error) {
 	revision, err := s.GetRevision(ctx, opt.RevisionID)
 	if err != nil {
 		return nil, err
@@ -66,8 +66,8 @@ func (s *OomStore) ChannelExport(ctx context.Context, opt types.ChannelExportOpt
 	return types.NewExportResult(header, stream, exportErr), nil
 }
 
-func (s *OomStore) Export(ctx context.Context, opt types.ExportOpt) error {
-	exportResult, err := s.ChannelExport(ctx, types.ChannelExportOpt{
+func (s *OomStore) ExportBatch(ctx context.Context, opt types.ExportBatchOpt) error {
+	exportResult, err := s.ChannelExportBatch(ctx, types.ChannelExportBatchOpt{
 		RevisionID:   opt.RevisionID,
 		FeatureNames: opt.FeatureNames,
 		Limit:        opt.Limit,

--- a/pkg/oomstore/export_test.go
+++ b/pkg/oomstore/export_test.go
@@ -38,7 +38,7 @@ func TestChannelExport(t *testing.T) {
 
 	testCases := []struct {
 		description  string
-		opt          types.ChannelExportOpt
+		opt          types.ChannelExportBatchOpt
 		features     types.FeatureList
 		exportStream <-chan types.ExportRecord
 		exportError  <-chan error
@@ -46,7 +46,7 @@ func TestChannelExport(t *testing.T) {
 	}{
 		{
 			description: "provide no features, should return all feature values",
-			opt: types.ChannelExportOpt{
+			opt: types.ChannelExportBatchOpt{
 				FeatureNames: []string{},
 				RevisionID:   revisionID,
 			},
@@ -56,7 +56,7 @@ func TestChannelExport(t *testing.T) {
 		},
 		{
 			description: "provide one feature, should return one feature values",
-			opt: types.ChannelExportOpt{
+			opt: types.ChannelExportBatchOpt{
 				FeatureNames: []string{"price"},
 				RevisionID:   revisionID,
 			},
@@ -66,7 +66,7 @@ func TestChannelExport(t *testing.T) {
 		},
 		{
 			description: "provide revision and one feature name, should return one feature values",
-			opt: types.ChannelExportOpt{
+			opt: types.ChannelExportBatchOpt{
 				FeatureNames: []string{"price"},
 				RevisionID:   revisionID,
 			},
@@ -76,7 +76,7 @@ func TestChannelExport(t *testing.T) {
 		},
 		{
 			description: "empty stream",
-			opt: types.ChannelExportOpt{
+			opt: types.ChannelExportBatchOpt{
 				FeatureNames: []string{"price"},
 				RevisionID:   revisionID,
 			},
@@ -118,7 +118,7 @@ func TestChannelExport(t *testing.T) {
 			}).Return(tc.exportStream, tc.exportError)
 
 			// execute and compare results
-			actual, err := store.ChannelExport(context.Background(), tc.opt)
+			actual, err := store.ChannelExportBatch(context.Background(), tc.opt)
 			assert.NoError(t, err)
 			values := make([][]interface{}, 0)
 			for row := range actual.Data {

--- a/pkg/oomstore/types/options.go
+++ b/pkg/oomstore/types/options.go
@@ -30,7 +30,7 @@ type CreateGroupOpt struct {
 	Description string
 }
 
-type ChannelExportOpt struct {
+type ChannelExportBatchOpt struct {
 	RevisionID   int
 	FeatureNames []string
 	Limit        *uint64
@@ -42,7 +42,7 @@ type ChannelExportStreamOpt struct {
 	Limit            *uint64
 }
 
-type ExportOpt struct {
+type ExportBatchOpt struct {
 	RevisionID     int
 	FeatureNames   []string
 	Limit          *uint64


### PR DESCRIPTION
This PR renames API `Export` to `ExportBatch`. In later PRs, we will implement a new `Export` API, which can export both batch and streaming features.

related to #802 