### PR TITLE
Jinghan/refactor Export return type

### DIFF
--- a/internal/database/offline/bigquery/export.go
+++ b/internal/database/offline/bigquery/export.go
@@ -67,7 +67,7 @@ func bigqueryQueryExportResults(ctx context.Context, dbOpt dbutil.DBOpt, opt off
 	return stream, errs
 }
 
-func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/internal/database/offline/mock_offline/store.go
+++ b/internal/database/offline/mock_offline/store.go
@@ -65,11 +65,11 @@ func (mr *MockStoreMockRecorder) CreateTable(ctx, opt interface{}) *gomock.Call 
 }
 
 // Export mocks base method.
-func (m *MockStore) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (m *MockStore) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Export", ctx, opt)
-	ret0, _ := ret[0].(<-chan types.ExportRecord)
-	ret1, _ := ret[1].(<-chan error)
+	ret0, _ := ret[0].(*types.ExportResult)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/internal/database/offline/mysql/store.go
+++ b/internal/database/offline/mysql/store.go
@@ -41,7 +41,7 @@ func (db *DB) ExportOneGroup(ctx context.Context, opt offline.ExportOneGroupOpt)
 	return sqlutil.ExportOneGroup(ctx, db.DB, opt, Backend)
 }
 
-func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }
 

--- a/internal/database/offline/postgres/store.go
+++ b/internal/database/offline/postgres/store.go
@@ -38,7 +38,7 @@ func (db *DB) ExportOneGroup(ctx context.Context, opt offline.ExportOneGroupOpt)
 	return sqlutil.ExportOneGroup(ctx, db.DB, opt, Backend)
 }
 
-func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 
 }

--- a/internal/database/offline/redshift/store.go
+++ b/internal/database/offline/redshift/store.go
@@ -41,7 +41,7 @@ func (db *DB) ExportOneGroup(ctx context.Context, opt offline.ExportOneGroupOpt)
 	return sqlutil.ExportOneGroup(ctx, db.DB, opt, Backend)
 }
 
-func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }
 

--- a/internal/database/offline/snowflake/store.go
+++ b/internal/database/offline/snowflake/store.go
@@ -55,7 +55,7 @@ func (db *DB) ExportOneGroup(ctx context.Context, opt offline.ExportOneGroupOpt)
 	return sqlutil.ExportOneGroup(ctx, db.DB, opt, Backend)
 }
 
-func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }
 

--- a/internal/database/offline/sqlite/store.go
+++ b/internal/database/offline/sqlite/store.go
@@ -41,7 +41,7 @@ func (db *DB) ExportOneGroup(ctx context.Context, opt offline.ExportOneGroupOpt)
 	return sqlutil.ExportOneGroup(ctx, db.DB, opt, Backend)
 }
 
-func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (<-chan types.ExportRecord, <-chan error) {
+func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }
 

--- a/internal/database/offline/store.go
+++ b/internal/database/offline/store.go
@@ -10,7 +10,7 @@ import (
 type Store interface {
 	Join(ctx context.Context, opt JoinOpt) (*types.JoinResult, error)
 	ExportOneGroup(ctx context.Context, opt ExportOneGroupOpt) (<-chan types.ExportRecord, <-chan error)
-	Export(ctx context.Context, opt ExportOpt) (<-chan types.ExportRecord, <-chan error)
+	Export(ctx context.Context, opt ExportOpt) (*types.ExportResult, error)
 	Import(ctx context.Context, opt ImportOpt) (int64, error)
 	Push(ctx context.Context, opt PushOpt) error
 

--- a/internal/database/offline/test_impl/export.go
+++ b/internal/database/offline/test_impl/export.go
@@ -92,19 +92,20 @@ func TestExport(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyS
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			actual, errs := store.Export(ctx, tc.opt)
+			result, err := store.Export(ctx, tc.opt)
 			values := make([][]interface{}, 0)
-			for row := range actual {
+			for row := range result.Data {
 				values = append(values, row)
 			}
 			if tc.expectedError != nil {
-				assert.EqualError(t, <-errs, tc.expectedError.Error())
+				assert.EqualError(t, err, tc.expectedError.Error())
 			} else {
 				fmt.Println("expected: ", tc.expected)
 				fmt.Println("actual: ", values)
 
 				assert.ElementsMatch(t, tc.expected, values)
-				assert.NoError(t, <-errs)
+				assert.NoError(t, err)
+				assert.NoError(t, result.CheckStreamError())
 			}
 		})
 	}

--- a/pkg/oomstore/export.go
+++ b/pkg/oomstore/export.go
@@ -181,7 +181,7 @@ func (s *OomStore) ChannelExport(ctx context.Context, opt types.ChannelExportOpt
 		}
 	}
 
-	stream, exportErr := s.offline.Export(ctx, offline.ExportOpt{
+	result, err := s.offline.Export(ctx, offline.ExportOpt{
 		SnapshotTables: snapshotTables,
 		CdcTables:      cdcTables,
 		Features:       featureMap,
@@ -189,9 +189,10 @@ func (s *OomStore) ChannelExport(ctx context.Context, opt types.ChannelExportOpt
 		EntityName:     features[0].Group.Entity.Name,
 		Limit:          opt.Limit,
 	})
-
-	header := append([]string{features[0].Group.Entity.Name}, features.Names()...)
-	return types.NewExportResult(header, stream, exportErr), nil
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // key: group_Id, value: slice of features


### PR DESCRIPTION
This PR changes the return type of offline method `Export` to 
```
Export(ctx context.Context, opt ExportOpt) (*types.ExportResult, error)
type ExportResult struct {
	Header []string
	Data   <-chan ExportRecord
	error  <-chan error
}
```

So that we generate `Header` and `Data` in the same place.

related to #962 