### PR TITLE
feat(oomsotre/stream-cache): make stream push processor configurable

### DIFF
--- a/pkg/oomstore/oomstore.go
+++ b/pkg/oomstore/oomstore.go
@@ -46,7 +46,7 @@ func Open(ctx context.Context, opt types.OomStoreConfig) (*OomStore, error) {
 		offline:  offlineStore,
 		metadata: metadataStore,
 	}
-	store.InitStreamPushProcessor(ctx)
+	store.InitStreamPushProcessor(ctx, opt.StreamPushProcessor)
 
 	return store, nil
 }

--- a/pkg/oomstore/types/config.go
+++ b/pkg/oomstore/types/config.go
@@ -26,6 +26,15 @@ type OomStoreConfig struct {
 	MetadataStore MetadataStoreConfig `yaml:"metadata-store"`
 	OfflineStore  OfflineStoreConfig  `yaml:"offline-store"`
 	OnlineStore   OnlineStoreConfig   `yaml:"online-store"`
+
+	StreamPushProcessor *StreamPushProcessorConfig `yaml:"stream-push-processor"`
+}
+
+type StreamPushProcessorConfig struct {
+	RevisionInterval time.Duration `yaml:"revision-interval"`
+	Period           time.Duration `yaml:"period"`
+	MinPeriod        time.Duration `yaml:"min-period"`
+	BufferSize       int           `yaml:"buffer-size"`
 }
 
 type OnlineStoreConfig struct {


### PR DESCRIPTION
resolve: #980 

example:

```yaml
online-store:
  postgres:
    host: 127.0.0.1
    port: 25432
    user: postgres
    password: postgres
    database: oomstore

offline-store:
  postgres:
    host: 127.0.0.1
    port: 25432
    user: postgres
    password: postgres
    database: oomstore

metadata-store:
  postgres:
    host: 127.0.0.1
    port: 25432
    user: postgres
    password: postgres
    database: oomstore

stream-push-processor:
 revision-interval: 24h
 period: 5m
 min-period: 2m
 buffer-interval: 1000
```