### PR TITLE
Jinghan/Add `unix_milli` column to snapshot table

### DIFF
--- a/internal/database/offline/test_impl/join.go
+++ b/internal/database/offline/test_impl/join.go
@@ -147,11 +147,13 @@ func prepareFeatures(oneGroup bool) (types.FeatureList, map[string]types.Feature
 	groupBasic := &types.Group{
 		ID:       1,
 		Name:     "device_basic",
+		Entity:   &types.Entity{Name: "device"},
 		Category: types.CategoryBatch,
 	}
 	groupAdvanced := &types.Group{
 		ID:       2,
 		Name:     "device_advanced",
+		Entity:   &types.Entity{Name: "device"},
 		Category: types.CategoryBatch,
 	}
 	price := &types.Feature{

--- a/internal/database/offline/test_impl/snapshot.go
+++ b/internal/database/offline/test_impl/snapshot.go
@@ -30,10 +30,10 @@ func TestSnapshot(t *testing.T, prepareStore PrepareStoreFn, destroyStore Destro
 	}
 	features, _ := prepareFeatures(true)
 
-	buildTestSnapshotTable(ctx, t, store, features, 1, "offline_stream_snapshot_1_1", &offline.CSVSource{
-		Reader: bufio.NewReader(strings.NewReader(`1234,xiaomi,100
-1235,apple,200
-1236,oneplus,155
+	buildTestSnapshotTable(ctx, t, store, append(features, unixMilli), 1, "offline_stream_snapshot_1_1", &offline.CSVSource{
+		Reader: bufio.NewReader(strings.NewReader(`1234,xiaomi,100,1
+1235,apple,200,5
+1236,oneplus,155,8
 `)),
 		Delimiter: ",",
 	})

--- a/pkg/oomstore/revision.go
+++ b/pkg/oomstore/revision.go
@@ -47,6 +47,7 @@ func (s *OomStore) createFirstSnapshotTable(ctx context.Context, revision *types
 		TableName: snapshotTable,
 		Entity:    revision.Group.Entity,
 		Features:  features,
+		IsCDC:     true, // In order to add `unix_milli` column, set IsCDC as true temporarily
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds `unix_milli` column to streaming feature's snapshot table.

TODO:

- [ ] refactor offline method `CreateTable`: handle `unix_milli` issue separately


related to #994 