### PR TITLE
Jinghan/modify offline method `CreateTable`

### DIFF
--- a/internal/database/dbutil/schema.go
+++ b/internal/database/dbutil/schema.go
@@ -26,12 +26,12 @@ func (c ColumnList) Names() []string {
 func BuildTableSchema(
 	tableName string,
 	entity *types.Entity,
-	isCDC bool,
+	hasUnixMilli bool,
 	features types.FeatureList,
 	pkFields []string,
 	backend types.BackendType,
 ) string {
-	columns := parseColumns(entity, isCDC, features, backend)
+	columns := parseColumns(entity, hasUnixMilli, features, backend)
 	return createTableDDL(tableName, columns, pkFields, backend)
 }
 
@@ -82,7 +82,7 @@ func BuildIndexDDL(tableName string, indexName string, fields []string, backend 
 	}
 }
 
-func parseColumns(entity *types.Entity, isCDC bool, features types.FeatureList, backend types.BackendType) (rs []Column) {
+func parseColumns(entity *types.Entity, hasUnixMilli bool, features types.FeatureList, backend types.BackendType) (rs []Column) {
 	// entity column
 	{
 		c := Column{Name: entity.Name, ValueType: types.String}
@@ -101,7 +101,7 @@ func parseColumns(entity *types.Entity, isCDC bool, features types.FeatureList, 
 
 	// unix_milli column
 	{
-		if isCDC {
+		if hasUnixMilli {
 			valueType := types.Int64
 			dbType, err := DBValueType(backend, valueType)
 			if err != nil {

--- a/internal/database/offline/bigquery/store_test.go
+++ b/internal/database/offline/bigquery/store_test.go
@@ -107,3 +107,7 @@ func TestSnapshot(t *testing.T) {
 	t.Skip()
 	test_impl.TestSnapshot(t, prepareStore, destroyStore(DATASET_ID))
 }
+
+func TestCreateTable(t *testing.T) {
+	test_impl.TestCreateTable(t, prepareStore, destroyStore(DATASET_ID))
+}

--- a/internal/database/offline/mysql/store_test.go
+++ b/internal/database/offline/mysql/store_test.go
@@ -66,3 +66,7 @@ func TestTableSchema(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateTable(t *testing.T) {
+	test_impl.TestCreateTable(t, prepareStore, runtime_mysql.DestroyStore(DATABASE))
+}

--- a/internal/database/offline/postgres/store_test.go
+++ b/internal/database/offline/postgres/store_test.go
@@ -58,3 +58,7 @@ func TestTableSchema(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateTable(t *testing.T) {
+	test_impl.TestCreateTable(t, prepareStore, runtime_pg.DestroyStore(DATABASE))
+}

--- a/internal/database/offline/redshift/store_test.go
+++ b/internal/database/offline/redshift/store_test.go
@@ -102,3 +102,7 @@ func TestTableSchema(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateTable(t *testing.T) {
+	test_impl.TestCreateTable(t, prepareStore, destroyStore(DATABASE))
+}

--- a/internal/database/offline/snowflake/store_test.go
+++ b/internal/database/offline/snowflake/store_test.go
@@ -105,3 +105,7 @@ func TestTableSchema(t *testing.T) {
 	}
 	require.ElementsMatch(t, expected.Fields, actual.Fields)
 }
+
+func TestCreateTable(t *testing.T) {
+	test_impl.TestCreateTable(t, prepareStore, destroyStore(DATABASE))
+}

--- a/internal/database/offline/sqlite/store_test.go
+++ b/internal/database/offline/sqlite/store_test.go
@@ -68,3 +68,7 @@ func TestTableSchema(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateTable(t *testing.T) {
+	test_impl.TestCreateTable(t, prepareStore, destroyStore)
+}

--- a/internal/database/offline/sqlutil/create_table.go
+++ b/internal/database/offline/sqlutil/create_table.go
@@ -2,6 +2,7 @@ package sqlutil
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/oom-ai/oomstore/pkg/errdefs"
@@ -12,24 +13,34 @@ import (
 )
 
 func CreateTable(ctx context.Context, db *sqlx.DB, opt offline.CreateTableOpt, backend types.BackendType) error {
-	if opt.IsCDC {
-		// Create index (entity_key, unix_milli) on cdc table
-		schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, true, opt.Features, nil, backend)
-		if _, err := db.ExecContext(ctx, schema); err != nil {
-			return errdefs.WithStack(err)
-		}
-		indexFields := []string{opt.Entity.Name, "unix_milli"}
-		indexDDL := dbutil.BuildIndexDDL(opt.TableName, "idx", indexFields, backend)
-		if _, err := db.ExecContext(ctx, indexDDL); err != nil {
-			return errdefs.WithStack(err)
-		}
-	} else {
-		// Create primary key (entity_key) on snapshot table
+	switch opt.TableType {
+	case types.TableBatchSnapshot:
+		// Create primary key (entity_key) on batch snapshot table
 		pkFields := []string{opt.Entity.Name}
 		schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, false, opt.Features, pkFields, backend)
 		if _, err := db.ExecContext(ctx, schema); err != nil {
 			return errdefs.WithStack(err)
 		}
+	case types.TableStreamSnapshot:
+		// Create primary key (entity_key) on stream snapshot table
+		pkFields := []string{opt.Entity.Name}
+		schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, true, opt.Features, pkFields, backend)
+		if _, err := db.ExecContext(ctx, schema); err != nil {
+			return errdefs.WithStack(err)
+		}
+	case types.TableStreamCdc:
+		schema := dbutil.BuildTableSchema(opt.TableName, opt.Entity, true, opt.Features, nil, backend)
+		if _, err := db.ExecContext(ctx, schema); err != nil {
+			return errdefs.WithStack(err)
+		}
+		// Create index (entity_key, unix_milli) on stream cdc table
+		indexFields := []string{opt.Entity.Name, "unix_milli"}
+		indexDDL := dbutil.BuildIndexDDL(opt.TableName, "idx", indexFields, backend)
+		if _, err := db.ExecContext(ctx, indexDDL); err != nil {
+			return errdefs.WithStack(err)
+		}
+	default:
+		panic(fmt.Sprintf("unsupported table type %s", opt.TableType))
 	}
 	return nil
 }

--- a/internal/database/offline/test_impl/create_table.go
+++ b/internal/database/offline/test_impl/create_table.go
@@ -35,19 +35,28 @@ func TestCreateTable(t *testing.T, prepareStore PrepareStoreFn, destroyStore Des
 		{
 			describtion: "cdc table (with unix_milli)",
 			opt: offline.CreateTableOpt{
-				TableName: tableName,
+				TableName: tableName + "_0",
 				Entity:    &entity,
 				Features:  features,
-				IsCDC:     true,
+				TableType: types.TableStreamCdc,
 			},
 		},
 		{
-			describtion: "snapshot table (without_milli)",
+			describtion: "stream snapshot table (with unix_milli)",
 			opt: offline.CreateTableOpt{
-				TableName: tableName,
+				TableName: tableName + "_1",
 				Entity:    &entity,
 				Features:  features,
-				IsCDC:     false,
+				TableType: types.TableStreamSnapshot,
+			},
+		},
+		{
+			describtion: "batch snapshot table (without unix_milli)",
+			opt: offline.CreateTableOpt{
+				TableName: tableName + "_2",
+				Entity:    &entity,
+				Features:  features,
+				TableType: types.TableBatchSnapshot,
 			},
 		},
 	}

--- a/internal/database/offline/test_impl/export.go
+++ b/internal/database/offline/test_impl/export.go
@@ -2,7 +2,6 @@ package test_impl
 
 import (
 	"bufio"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -100,9 +99,6 @@ func TestExport(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyS
 			if tc.expectedError != nil {
 				assert.EqualError(t, err, tc.expectedError.Error())
 			} else {
-				fmt.Println("expected: ", tc.expected)
-				fmt.Println("actual: ", values)
-
 				assert.ElementsMatch(t, tc.expected, values)
 				assert.NoError(t, err)
 				assert.NoError(t, result.CheckStreamError())

--- a/internal/database/offline/test_impl/push.go
+++ b/internal/database/offline/test_impl/push.go
@@ -75,7 +75,7 @@ func TestPush(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroySto
 			TableName: dbutil.OfflineStreamCdcTableName(group.ID, revision),
 			Entity:    &entity,
 			Features:  features,
-			IsCDC:     true,
+			TableType: types.TableStreamCdc,
 		})
 		require.NoError(t, err)
 

--- a/internal/database/offline/types.go
+++ b/internal/database/offline/types.go
@@ -74,5 +74,5 @@ type CreateTableOpt struct {
 	TableName string
 	Entity    *types.Entity
 	Features  types.FeatureList
-	IsCDC     bool
+	TableType types.TableType
 }

--- a/pkg/oomstore/cache.go
+++ b/pkg/oomstore/cache.go
@@ -184,7 +184,7 @@ func (p *StreamPushProcessor) newRevision(ctx context.Context, s *OomStore, grou
 		TableName: dbutil.OfflineStreamCdcTableName(groupID, revision),
 		Entity:    entity,
 		Features:  features,
-		IsCDC:     true,
+		TableType: types.TableStreamCdc,
 	}); err != nil {
 		return err
 	}

--- a/pkg/oomstore/revision.go
+++ b/pkg/oomstore/revision.go
@@ -47,7 +47,7 @@ func (s *OomStore) createFirstSnapshotTable(ctx context.Context, revision *types
 		TableName: snapshotTable,
 		Entity:    revision.Group.Entity,
 		Features:  features,
-		IsCDC:     true, // In order to add `unix_milli` column, set IsCDC as true temporarily
+		TableType: types.TableStreamSnapshot,
 	}); err != nil {
 		return err
 	}

--- a/pkg/oomstore/types/types.go
+++ b/pkg/oomstore/types/types.go
@@ -7,6 +7,14 @@ const (
 	CategoryStream Category = "stream"
 )
 
+type TableType = string
+
+const (
+	TableBatchSnapshot  TableType = "batch_snapshot"
+	TableStreamSnapshot TableType = "stream_snapshot"
+	TableStreamCdc      TableType = "stream_cdc"
+)
+
 type ExportRecord []interface{}
 
 func (r ExportRecord) EntityKey() string {


### PR DESCRIPTION
This PR refactors offline method `CreateTable`: replace `IsCDC` by `TableType`, so that we could differentiate different table types clearly.

related to #994 