### PR TITLE
Jinghan/refactor helper `loadDataFromSource`

### DIFF
--- a/internal/database/offline/sqlutil/import.go
+++ b/internal/database/offline/sqlutil/import.go
@@ -12,9 +12,9 @@ import (
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
-type LoadData func(tx *sqlx.Tx, ctx context.Context, source *offline.CSVSource, tableName string, header []string, features types.FeatureList) error
+type LoadData func(tx *sqlx.Tx, ctx context.Context, opt dbutil.LoadDataFromSourceOpt) error
 
-func Import(ctx context.Context, db *sqlx.DB, opt offline.ImportOpt, loadData LoadData, backendType types.BackendType) (int64, error) {
+func Import(ctx context.Context, db *sqlx.DB, opt offline.ImportOpt, loadData LoadData, backend types.BackendType) (int64, error) {
 	var revision int64
 	err := dbutil.WithTransaction(db, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 		// create the data table
@@ -22,14 +22,21 @@ func Import(ctx context.Context, db *sqlx.DB, opt offline.ImportOpt, loadData Lo
 		if opt.NoPK {
 			pkFields = nil
 		}
-		schema := dbutil.BuildTableSchema(opt.SnapshotTableName, opt.Entity, false, opt.Features, pkFields, backendType)
+		schema := dbutil.BuildTableSchema(opt.SnapshotTableName, opt.Entity, false, opt.Features, pkFields, backend)
 		_, err := tx.ExecContext(ctx, schema)
 		if err != nil {
 			return errdefs.WithStack(err)
 		}
 
 		// populate the data table
-		err = loadData(tx, ctx, opt.Source, opt.SnapshotTableName, opt.Header, opt.Features)
+		err = loadData(tx, ctx, dbutil.LoadDataFromSourceOpt{
+			Source:    opt.Source,
+			Entity:    opt.Entity,
+			TableName: opt.SnapshotTableName,
+			Header:    opt.Header,
+			Features:  opt.Features,
+			Backend:   backend,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/oomstore/import.go
+++ b/pkg/oomstore/import.go
@@ -46,8 +46,14 @@ func (s *OomStore) Import(ctx context.Context, opt types.ImportOpt) (int, error)
 func (s *OomStore) csvReaderImport(ctx context.Context, opt *importOpt, dataSource *types.CsvReaderDataSource) (int, error) {
 	//make sure csv data source has all defined columns
 	reader := bufio.NewReader(dataSource.Reader)
+	source := &offline.CSVSource{
+		Reader:    reader,
+		Delimiter: dataSource.Delimiter,
+	}
 	// read header does not need pass down features
-	header, err := dbutil.ReadLine(reader, dataSource.Delimiter, nil, "")
+	header, err := dbutil.ReadLine(dbutil.ReadLineOpt{
+		Source: source,
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -76,10 +82,7 @@ func (s *OomStore) csvReaderImport(ctx context.Context, opt *importOpt, dataSour
 		Header:            cast.ToStringSlice(header),
 		Revision:          opt.Revision,
 		SnapshotTableName: snapshotTableName,
-		Source: &offline.CSVSource{
-			Reader:    reader,
-			Delimiter: dataSource.Delimiter,
-		},
+		Source:            source,
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This PR refactors helper functions `loadDataFromSource` and `ReadLine`, make them able to handle `unix_milli` when parsing data from source.

This refactor will be used in later PRs to load data for streaming features.

related to #804 