### PR TITLE
Jinghan/implement offline method `ImportStream`

### DIFF
--- a/internal/database/dbutil/schema.go
+++ b/internal/database/dbutil/schema.go
@@ -69,7 +69,8 @@ func BuildIndexDDL(tableName string, indexName string, fields []string, backend 
 	switch backend {
 	case types.BackendCassandra,
 		types.BackendMySQL,
-		types.BackendSQLite:
+		types.BackendSQLite,
+		types.BackendRedshift:
 		return fmt.Sprintf("CREATE INDEX %s ON %s (%s)", qt(indexName), qt(tableName), qt(fields...))
 	case types.BackendPostgres:
 		// omit the name when creating the index, and PG will assign a unique name automatically.

--- a/internal/database/offline/bigquery/import.go
+++ b/internal/database/offline/bigquery/import.go
@@ -70,6 +70,11 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 	return time.Now().UnixMilli(), nil
 }
 
+func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func convertValueTypeToBigQueryType(t types.ValueType) (bigquery.FieldType, error) {
 	switch t {
 	case types.String:

--- a/internal/database/offline/mock_offline/store.go
+++ b/internal/database/offline/mock_offline/store.go
@@ -94,6 +94,21 @@ func (mr *MockStoreMockRecorder) Import(ctx, opt interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockStore)(nil).Import), ctx, opt)
 }
 
+// ImportStream mocks base method.
+func (m *MockStore) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImportStream", ctx, opt)
+	ret0, _ := ret[0].(*offline.TimeRange)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportStream indicates an expected call of ImportStream.
+func (mr *MockStoreMockRecorder) ImportStream(ctx, opt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportStream", reflect.TypeOf((*MockStore)(nil).ImportStream), ctx, opt)
+}
+
 // Join mocks base method.
 func (m *MockStore) Join(ctx context.Context, opt offline.JoinOpt) (*types.JoinResult, error) {
 	m.ctrl.T.Helper()

--- a/internal/database/offline/mysql/store.go
+++ b/internal/database/offline/mysql/store.go
@@ -38,8 +38,7 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 }
 
 func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
-	//TODO implement me
-	panic("implement me")
+	return sqlutil.ImportStream(ctx, db.DB, opt, Backend)
 }
 
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {

--- a/internal/database/offline/mysql/store.go
+++ b/internal/database/offline/mysql/store.go
@@ -37,6 +37,11 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 	return sqlutil.Import(ctx, db.DB, opt, dbutil.LoadDataFromSource(Backend, MySQLBatchSize), Backend)
 }
 
+func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }

--- a/internal/database/offline/mysql/store_test.go
+++ b/internal/database/offline/mysql/store_test.go
@@ -49,8 +49,8 @@ func TestSnapshot(t *testing.T) {
 	test_impl.TestSnapshot(t, prepareStore, runtime_mysql.DestroyStore(DATABASE))
 }
 
-func TestPush(t *testing.T) {
-	test_impl.TestPush(t, prepareStore, runtime_mysql.DestroyStore(DATABASE))
+func TestImportStream(t *testing.T) {
+	test_impl.TestImportStream(t, prepareStore, runtime_mysql.DestroyStore(DATABASE))
 }
 
 func TestTableSchema(t *testing.T) {

--- a/internal/database/offline/postgres/store.go
+++ b/internal/database/offline/postgres/store.go
@@ -35,8 +35,7 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 }
 
 func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
-	//TODO implement me
-	panic("implement me")
+	return sqlutil.ImportStream(ctx, db.DB, opt, Backend)
 }
 
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {

--- a/internal/database/offline/postgres/store.go
+++ b/internal/database/offline/postgres/store.go
@@ -34,6 +34,11 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 	return sqlutil.Import(ctx, db.DB, opt, loadDataFromSource, Backend)
 }
 
+func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 

--- a/internal/database/offline/postgres/store_test.go
+++ b/internal/database/offline/postgres/store_test.go
@@ -37,6 +37,10 @@ func TestImport(t *testing.T) {
 	test_impl.TestImport(t, prepareStore, runtime_pg.DestroyStore(DATABASE))
 }
 
+func TestImportStream(t *testing.T) {
+	test_impl.TestImportStream(t, prepareStore, runtime_pg.DestroyStore(DATABASE))
+}
+
 func TestExport(t *testing.T) {
 	test_impl.TestExport(t, prepareStore, runtime_pg.DestroyStore(DATABASE))
 }

--- a/internal/database/offline/redshift/store.go
+++ b/internal/database/offline/redshift/store.go
@@ -39,8 +39,7 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 }
 
 func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
-	//TODO implement me
-	panic("implement me")
+	return sqlutil.ImportStream(ctx, db.DB, opt, Backend)
 }
 
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {

--- a/internal/database/offline/redshift/store.go
+++ b/internal/database/offline/redshift/store.go
@@ -38,6 +38,11 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 	return sqlutil.Import(ctx, db.DB, opt, dbutil.LoadDataFromSource(Backend, RedshiftBatchSize), Backend)
 }
 
+func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }

--- a/internal/database/offline/redshift/store_test.go
+++ b/internal/database/offline/redshift/store_test.go
@@ -86,6 +86,10 @@ func TestImport(t *testing.T) {
 	test_impl.TestImport(t, prepareStore, destroyStore(DATABASE))
 }
 
+func TestImportStream(t *testing.T) {
+	test_impl.TestImportStream(t, prepareStore, destroyStore(DATABASE))
+}
+
 func TestJoin(t *testing.T) {
 	test_impl.TestJoin(t, prepareStore, destroyStore(DATABASE))
 }

--- a/internal/database/offline/snowflake/store.go
+++ b/internal/database/offline/snowflake/store.go
@@ -51,6 +51,11 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 	return sqlutil.Import(ctx, db.DB, opt, dbutil.LoadDataFromSource(Backend, SnowflakeBatchSize), Backend)
 }
 
+func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }

--- a/internal/database/offline/sqlite/store.go
+++ b/internal/database/offline/sqlite/store.go
@@ -37,6 +37,11 @@ func (db *DB) Import(ctx context.Context, opt offline.ImportOpt) (int64, error) 
 	return sqlutil.Import(ctx, db.DB, opt, dbutil.LoadDataFromSource(Backend, SQLiteBatchSize), Backend)
 }
 
+func (db *DB) ImportStream(ctx context.Context, opt offline.ImportStreamOpt) (*offline.TimeRange, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportResult, error) {
 	return sqlutil.Export(ctx, db.DB, opt, Backend)
 }

--- a/internal/database/offline/sqlutil/import_stream.go
+++ b/internal/database/offline/sqlutil/import_stream.go
@@ -1,0 +1,117 @@
+package sqlutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+
+	"github.com/oom-ai/oomstore/internal/database/dbutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/oom-ai/oomstore/internal/database/offline"
+)
+
+const (
+	SQLBatchSize = 20
+)
+
+func ImportStream(ctx context.Context, db *sqlx.DB, opt offline.ImportStreamOpt, backend types.BackendType) (*offline.TimeRange, error) {
+	dbOpt := dbutil.DBOpt{
+		SqlxDB:  db,
+		Backend: backend,
+	}
+	doImportStreamOpt := DoImportStreamOpt{
+		ImportStreamOpt: opt,
+		LoadData:        dbutil.LoadDataFromSource(backend, SQLBatchSize),
+	}
+	return DoImportStream(ctx, dbOpt, doImportStreamOpt)
+}
+
+type DoImportStreamOpt struct {
+	offline.ImportStreamOpt
+	LoadData LoadData
+}
+
+func DoImportStream(ctx context.Context, dbOpt dbutil.DBOpt, opt DoImportStreamOpt) (*offline.TimeRange, error) {
+	var timeRange offline.TimeRange
+	err := dbutil.WithTransaction(dbOpt.SqlxDB, ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Step 1: create cdc table
+		tempTableName := dbutil.TempTable("offline_stream_cdc")
+		schema := dbutil.BuildTableSchema(tempTableName, opt.Entity, true, opt.Features, nil, dbOpt.Backend)
+		_, err := tx.ExecContext(ctx, schema)
+		if err != nil {
+			return errdefs.WithStack(err)
+		}
+		// Step 2: load data to the cdc table
+		err = opt.LoadData(tx, ctx, dbutil.LoadDataFromSourceOpt{
+			Source:    opt.Source,
+			Entity:    opt.Entity,
+			TableName: tempTableName,
+			Header:    opt.Header,
+			Features:  opt.Features,
+			Backend:   dbOpt.Backend,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Step 3: find time range of the cdc table, generate cdc and snapshot tables
+		res, err := getCdcTimeRange(ctx, tx, tempTableName, dbOpt.Backend)
+		if err != nil {
+			return err
+		}
+		timeRange = *res
+		group := opt.Features[0].Group
+		cdcTableName := dbutil.OfflineStreamCdcTableName(group.ID, timeRange.MinUnixMilli)
+		qt := dbutil.QuoteFn(dbOpt.Backend)
+		if _, err = tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", qt(tempTableName), qt(cdcTableName))); err != nil {
+			return errdefs.WithStack(err)
+		}
+		if err = CreateTable(ctx, dbOpt.SqlxDB, offline.CreateTableOpt{
+			TableName: dbutil.OfflineStreamSnapshotTableName(group.ID, timeRange.MinUnixMilli),
+			Entity:    opt.Entity,
+			Features:  opt.Features,
+			TableType: types.TableStreamSnapshot,
+		}, dbOpt.Backend); err != nil {
+			return err
+		}
+		if err = CreateTable(ctx, dbOpt.SqlxDB, offline.CreateTableOpt{
+			TableName: dbutil.OfflineStreamCdcTableName(group.ID, timeRange.MaxUnixMilli),
+			Entity:    opt.Entity,
+			Features:  opt.Features,
+			TableType: types.TableStreamCdc,
+		}, dbOpt.Backend); err != nil {
+			return err
+		}
+
+		// Step 4: generate second revision's snapshot table
+		if err = Snapshot(ctx, dbOpt, offline.SnapshotOpt{
+			Group:        group,
+			Features:     opt.Features,
+			Revision:     timeRange.MaxUnixMilli,
+			PrevRevision: timeRange.MinUnixMilli,
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	return &timeRange, err
+}
+
+func getCdcTimeRange(ctx context.Context, tx *sqlx.Tx, tableName string, backend types.BackendType) (*offline.TimeRange, error) {
+	qt := dbutil.QuoteFn(backend)
+	var timeRange offline.TimeRange
+	query := fmt.Sprintf(`
+		SELECT
+			MIN(%s) AS %s,
+			MAX(%s) AS %s
+		FROM %s`, qt("unix_milli"), qt("min_unix_milli"), qt("unix_milli"), qt("max_unix_milli"), qt(tableName))
+
+	if err := tx.GetContext(ctx, &timeRange, query); err != nil {
+		return nil, errdefs.WithStack(err)
+	}
+	return &timeRange, nil
+}

--- a/internal/database/offline/store.go
+++ b/internal/database/offline/store.go
@@ -11,6 +11,7 @@ type Store interface {
 	Join(ctx context.Context, opt JoinOpt) (*types.JoinResult, error)
 	Export(ctx context.Context, opt ExportOpt) (*types.ExportResult, error)
 	Import(ctx context.Context, opt ImportOpt) (int64, error)
+	ImportStream(ctx context.Context, opt ImportStreamOpt) (*TimeRange, error)
 	Push(ctx context.Context, opt PushOpt) error
 
 	CreateTable(ctx context.Context, opt CreateTableOpt) error

--- a/internal/database/offline/test_impl/import_stream.go
+++ b/internal/database/offline/test_impl/import_stream.go
@@ -1,0 +1,89 @@
+package test_impl
+
+import (
+	"bufio"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oom-ai/oomstore/internal/database/dbutil"
+	"github.com/oom-ai/oomstore/internal/database/offline"
+	"github.com/oom-ai/oomstore/pkg/oomstore/types"
+)
+
+func TestImportStream(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyStoreFn) {
+	t.Cleanup(destroyStore)
+
+	ctx, store := prepareStore(t)
+	defer store.Close()
+
+	entity := types.Entity{Name: "device"}
+	group := &types.Group{
+		ID:       1,
+		Name:     "device_basic",
+		Category: types.CategoryStream,
+		Entity:   &entity,
+	}
+	features := []*types.Feature{
+		{
+			Name:      "price",
+			ValueType: types.Int64,
+			Group:     group,
+		},
+		{
+			Name:      "model",
+			ValueType: types.String,
+			Group:     group,
+		},
+	}
+
+	opt := offline.ImportStreamOpt{
+		Entity: &entity,
+		Header: []string{"device", "unix_milli", "model", "price"},
+		Source: &offline.CSVSource{
+			Reader: bufio.NewReader(strings.NewReader(`1234,1,xiaomi,1899
+1235,5,apple,4999
+1236,8,huawei,5999
+1237,10,oneplus,3999
+1235,15,apple-1,5999
+1238,17,galaxy,6999
+`)),
+			Delimiter: ",",
+		},
+	}
+
+	t.Run("import stream features, succeed", func(t *testing.T) {
+		opt.Features = features
+		timeRange, err := store.ImportStream(ctx, opt)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), timeRange.MinUnixMilli)
+		assert.Equal(t, int64(17), timeRange.MaxUnixMilli)
+
+		result, err := store.Export(ctx, offline.ExportOpt{
+			SnapshotTables: map[int]string{1: dbutil.OfflineStreamSnapshotTableName(group.ID, 1)},
+			CdcTables:      map[int]string{1: dbutil.OfflineStreamCdcTableName(group.ID, 1)},
+			EntityName:     entity.Name,
+			UnixMilli:      15,
+			Features:       map[int]types.FeatureList{1: features},
+		})
+		assert.NoError(t, err)
+		records := make([][]interface{}, 0)
+		for row := range result.Data {
+			records = append(records, row)
+		}
+		assert.NoError(t, err)
+		assert.NoError(t, result.CheckStreamError())
+		sort.Slice(records, func(i, j int) bool {
+			return cast.ToString(records[i][0]) < cast.ToString(records[j][0])
+		})
+		assert.Equal(t, [][]interface{}{
+			{"1234", int64(1899), "xiaomi"},
+			{"1235", int64(5999), "apple-1"},
+			{"1236", int64(5999), "huawei"},
+			{"1237", int64(3999), "oneplus"},
+		}, records)
+	})
+}

--- a/internal/database/offline/types.go
+++ b/internal/database/offline/types.go
@@ -50,6 +50,18 @@ type ImportOpt struct {
 	NoPK              bool // TODO: to import cdc data temporarily for testing
 }
 
+type ImportStreamOpt struct {
+	Entity   *types.Entity
+	Features types.FeatureList
+	Header   []string
+	Source   *CSVSource
+}
+
+type TimeRange struct {
+	MinUnixMilli int64 `db:"min_unix_milli"`
+	MaxUnixMilli int64 `db:"max_unix_milli"`
+}
+
 type PushOpt struct {
 	GroupID      int
 	Revision     int64


### PR DESCRIPTION
This PR implements offline method `ImportStream`, which could bulk load historical values for streaming features.

related to #804

TODO:

- [ ] implement `ImportStream` for sqlite, snowflake, bigquery