### PR TITLE
refactor(pkg/oomstore): group's Entity and Category should not change

### DIFF
--- a/pkg/oomstore/apply.go
+++ b/pkg/oomstore/apply.go
@@ -124,6 +124,10 @@ func (s *OomStore) applyGroup(ctx context.Context, tx metadata.DBStore, newGroup
 		return nil, nil
 	}
 
+	if group.Entity.Name != newGroup.EntityName || group.Category != newGroup.Category {
+		return nil, errdefs.Errorf("group %+v conflicts with already existing group %+v", newGroup, group)
+	}
+
 	opt := metadata.UpdateGroupOpt{
 		GroupID: group.ID,
 	}


### PR DESCRIPTION
This PR fixes a bug in `apply`: if newly-created group conflicts with already-existing group in `entityName` or `category`, we should not allow the group to be changed.

resolve #1095 