### PR TITLE
refactor: use entity-key to represent plural to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ oomcli sync --revision-id 2
 
 ```bash
 oomcli get online \
-  --entity-keys 1006 \
+  --entity-key 1006 \
   --feature account.state,account.credit_score,account.account_age_days,account.has_2fa_installed,transaction_stats.transaction_count_7d,transaction_stats.transaction_count_30d
 ```
 

--- a/oomcli/cmd/get_online.go
+++ b/oomcli/cmd/get_online.go
@@ -41,8 +41,8 @@ func init() {
 
 	flags := getOnlineCmd.Flags()
 
-	flags.StringSliceVarP(&multiGetOpt.EntityKeys, "entity-keys", "k", nil, "entity keys")
-	_ = getOnlineCmd.MarkFlagRequired("entity-keys")
+	flags.StringSliceVarP(&multiGetOpt.EntityKeys, "entity-key", "k", nil, "entity keys")
+	_ = getOnlineCmd.MarkFlagRequired("entity-key")
 
 	flags.StringSliceVar(&multiGetOpt.FeatureNames, "feature", nil, "feature full names")
 	_ = getOnlineCmd.MarkFlagRequired("feature")


### PR DESCRIPTION
So that it is consistent to `--feature`