### PR TITLE
Refactor/yaml space

### DIFF
--- a/oomcli/cmd/serialize.go
+++ b/oomcli/cmd/serialize.go
@@ -171,6 +171,7 @@ func parseRecords(tokens []TokenList, wide, truncate bool) ([][]string, error) {
 
 func serializeInYaml(w io.Writer, items interface{}) error {
 	encoder := yaml.NewEncoder(w)
+	encoder.SetIndent(2)
 	defer encoder.Close()
 
 	slice := reflect.ValueOf(items).Field(0)

--- a/oomcli/test/test_get_meta_entity.sh
+++ b/oomcli/test/test_get_meta_entity.sh
@@ -30,16 +30,16 @@ kind: Entity
 name: device
 description: device
 groups:
-    - name: phone
-      category: batch
-      description: phone
-      features:
-        - name: price
-          value-type: int64
-          description: price
-        - name: model
-          value-type: string
-          description: model
+  - name: phone
+    category: batch
+    description: phone
+    features:
+      - name: price
+        value-type: int64
+        description: price
+      - name: model
+        value-type: string
+        description: model
 '
 
 actual=$(oomcli get meta entity device -o yaml)
@@ -48,48 +48,48 @@ assert_eq "$case" "$expected" "$actual"
 case='oomcli get meta entity -o yaml: multiple entities'
 expected='
 items:
-    - kind: Entity
-      name: device
-      description: device
-      groups:
-        - name: phone
-          category: batch
-          description: phone
-          features:
-            - name: price
-              value-type: int64
-              description: price
-            - name: model
-              value-type: string
-              description: model
-    - kind: Entity
-      name: user
-      description: user
-      groups:
-        - name: student
-          category: batch
-          description: student
-          features:
-            - name: name
-              value-type: string
-              description: name
-            - name: gender
-              value-type: string
-              description: gender
-            - name: age
-              value-type: int64
-              description: age
-        - name: user-click
-          category: stream
-          snapshot-interval: 1s
-          description: user click post feature
-          features:
-            - name: last_5_click_posts
-              value-type: string
-              description: user last 5 click posts
-            - name: number_of_user_starred_posts
-              value-type: int64
-              description: number of posts that users starred today
+  - kind: Entity
+    name: device
+    description: device
+    groups:
+      - name: phone
+        category: batch
+        description: phone
+        features:
+          - name: price
+            value-type: int64
+            description: price
+          - name: model
+            value-type: string
+            description: model
+  - kind: Entity
+    name: user
+    description: user
+    groups:
+      - name: student
+        category: batch
+        description: student
+        features:
+          - name: name
+            value-type: string
+            description: name
+          - name: gender
+            value-type: string
+            description: gender
+          - name: age
+            value-type: int64
+            description: age
+      - name: user-click
+        category: stream
+        snapshot-interval: 1s
+        description: user click post feature
+        features:
+          - name: last_5_click_posts
+            value-type: string
+            description: user last 5 click posts
+          - name: number_of_user_starred_posts
+            value-type: int64
+            description: number of posts that users starred today
 '
 
 actual=$(oomcli get meta entity -o yaml)

--- a/oomcli/test/test_get_meta_feature.sh
+++ b/oomcli/test/test_get_meta_feature.sh
@@ -59,41 +59,41 @@ assert_eq "$case" "$expected" "$actual"
 case='oomcli get meta feature: multiple features'
 expected='
 items:
-    - kind: Feature
-      name: price
-      group-name: phone
-      value-type: int64
-      description: price
-    - kind: Feature
-      name: model
-      group-name: phone
-      value-type: string
-      description: model
-    - kind: Feature
-      name: name
-      group-name: student
-      value-type: string
-      description: name
-    - kind: Feature
-      name: gender
-      group-name: student
-      value-type: string
-      description: gender
-    - kind: Feature
-      name: age
-      group-name: student
-      value-type: int64
-      description: age
-    - kind: Feature
-      name: last_5_click_posts
-      group-name: user-click
-      value-type: string
-      description: user last 5 click posts
-    - kind: Feature
-      name: number_of_user_starred_posts
-      group-name: user-click
-      value-type: int64
-      description: number of posts that users starred today
+  - kind: Feature
+    name: price
+    group-name: phone
+    value-type: int64
+    description: price
+  - kind: Feature
+    name: model
+    group-name: phone
+    value-type: string
+    description: model
+  - kind: Feature
+    name: name
+    group-name: student
+    value-type: string
+    description: name
+  - kind: Feature
+    name: gender
+    group-name: student
+    value-type: string
+    description: gender
+  - kind: Feature
+    name: age
+    group-name: student
+    value-type: int64
+    description: age
+  - kind: Feature
+    name: last_5_click_posts
+    group-name: user-click
+    value-type: string
+    description: user last 5 click posts
+  - kind: Feature
+    name: number_of_user_starred_posts
+    group-name: user-click
+    value-type: int64
+    description: number of posts that users starred today
 '
 
 actual=$(oomcli get meta feature -o yaml)

--- a/oomcli/test/test_get_meta_group.sh
+++ b/oomcli/test/test_get_meta_group.sh
@@ -40,12 +40,12 @@ entity-name: device
 category: batch
 description: phone
 features:
-    - name: price
-      value-type: int64
-      description: price
-    - name: model
-      value-type: string
-      description: model
+  - name: price
+    value-type: int64
+    description: price
+  - name: model
+    value-type: string
+    description: model
 '
 
 actual=$(oomcli get meta group phone -o yaml)
@@ -54,46 +54,46 @@ assert_eq "$case" "$expected" "$actual"
 case='oomcli get meta group -o yaml: multiple groups'
 expected='
 items:
-    - kind: Group
-      name: phone
-      entity-name: device
-      category: batch
-      description: phone
-      features:
-        - name: price
-          value-type: int64
-          description: price
-        - name: model
-          value-type: string
-          description: model
-    - kind: Group
-      name: student
-      entity-name: user
-      category: batch
-      description: student
-      features:
-        - name: name
-          value-type: string
-          description: name
-        - name: gender
-          value-type: string
-          description: gender
-        - name: age
-          value-type: int64
-          description: age
-    - kind: Group
-      name: user-click
-      entity-name: user
-      category: stream
-      snapshot-interval: 1s
-      description: user click post feature
-      features:
-        - name: last_5_click_posts
-          value-type: string
-          description: user last 5 click posts
-        - name: number_of_user_starred_posts
-          value-type: int64
-          description: number of posts that users starred today
+  - kind: Group
+    name: phone
+    entity-name: device
+    category: batch
+    description: phone
+    features:
+      - name: price
+        value-type: int64
+        description: price
+      - name: model
+        value-type: string
+        description: model
+  - kind: Group
+    name: student
+    entity-name: user
+    category: batch
+    description: student
+    features:
+      - name: name
+        value-type: string
+        description: name
+      - name: gender
+        value-type: string
+        description: gender
+      - name: age
+        value-type: int64
+        description: age
+  - kind: Group
+    name: user-click
+    entity-name: user
+    category: stream
+    snapshot-interval: 1s
+    description: user click post feature
+    features:
+      - name: last_5_click_posts
+        value-type: string
+        description: user last 5 click posts
+      - name: number_of_user_starred_posts
+        value-type: int64
+        description: number of posts that users starred today
 '
 actual=$(oomcli get meta group -o yaml)
 assert_eq "$case" "$expected" "$actual"


### PR DESCRIPTION
This PR sets the indentation of YAML to 2, which is the community-recommended format, see:

https://developers.home-assistant.io/docs/documenting/yaml-style-guide/#block-style-sequences

https://github.com/flathub/flathub/wiki/YAML-Style-Guide