### PR TITLE
Fix/batch revision

### DIFF
--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -66,7 +66,7 @@ func (s *OomStore) Sync(ctx context.Context, opt types.SyncOpt) error {
 			return err
 		}
 		if !revision.Anchored {
-			newRevision := time.Now().Unix()
+			newRevision := time.Now().UnixMilli()
 			newChored := true
 			// Update revision timestamp using current timestamp
 			if err = tx.UpdateRevision(c, metadata.UpdateRevisionOpt{


### PR DESCRIPTION
The revision of the batch group is in seconds and the revision of the stream group is in milliseconds.
see:
 
```shell
$ oomcli get meta revision
ID  REVISION       GROUP             SNAPSHOT-TABLE               CDC-TABLE  DESCRIPTION
1   0              account           offline_batch_snapshot_1_1              dummy revision
2   1643335561     account           offline_batch_snapshot_1_2              sample account data
3   0              txn_stats         offline_batch_snapshot_2_3              dummy revision
4   1643335561     txn_stats         offline_batch_snapshot_2_4              sample txn stats data
5   0              recent_txn_stats  offline_stream_snapshot_3_0             dummy revision
6   1643335948800  recent_txn_stats
```

This PR is all set to milliseconds