### PR TITLE
feat(pkg/oomstore): check group category in API Push

### DIFF
--- a/pkg/oomstore/push.go
+++ b/pkg/oomstore/push.go
@@ -24,6 +24,9 @@ func (s *OomStore) Push(ctx context.Context, opt types.PushOpt) error {
 
 	entity := features[0].Entity()
 	group := features[0].Group
+	if group.Category != types.CategoryStream {
+		return errdefs.Errorf("Push API is for streaming features only")
+	}
 	if !stringSliceEqual(features.Names(), featureNames) {
 		return errdefs.Errorf("FeatureNames %v does not match with group's features %v", featureNames, features.Names())
 	}


### PR DESCRIPTION
API `Push` can only be used by streaming features. This PR checks group category before pushing data to offline/online store.