### PR TITLE
refactor(oomcli/sync): the parameter revision-id set to not required

### DIFF
--- a/oomcli/cmd/sync.go
+++ b/oomcli/cmd/sync.go
@@ -42,7 +42,6 @@ func init() {
 	flags.StringVarP(&syncOpt.GroupName, "group-name", "g", "", "group name")
 
 	syncOpt.RevisionID = flags.IntP("revision-id", "r", 0, "group revision id")
-	_ = syncCmd.MarkFlagRequired("revision-id")
 
 	flags.IntVarP(&syncOpt.PurgeDelay, "purge-delay", "", 0, "wait time in seconds before purging the old revision")
 }


### PR DESCRIPTION
fix #1139 