### PR TITLE
Jinghan/add `ListGroupOpt` to metadata method `ListGroup`

### DIFF
--- a/internal/database/metadata/mock_metadata/store.go
+++ b/internal/database/metadata/mock_metadata/store.go
@@ -291,18 +291,18 @@ func (mr *MockStoreMockRecorder) ListFeature(ctx, opt interface{}) *gomock.Call 
 }
 
 // ListGroup mocks base method.
-func (m *MockStore) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
+func (m *MockStore) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListGroup", ctx, entityID, groupIDs)
+	ret := m.ctrl.Call(m, "ListGroup", ctx, opt)
 	ret0, _ := ret[0].(types.GroupList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListGroup indicates an expected call of ListGroup.
-func (mr *MockStoreMockRecorder) ListGroup(ctx, entityID, groupIDs interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) ListGroup(ctx, opt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockStore)(nil).ListGroup), ctx, entityID, groupIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockStore)(nil).ListGroup), ctx, opt)
 }
 
 // ListRevision mocks base method.
@@ -652,18 +652,18 @@ func (mr *MockDBStoreMockRecorder) ListFeature(ctx, opt interface{}) *gomock.Cal
 }
 
 // ListGroup mocks base method.
-func (m *MockDBStore) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
+func (m *MockDBStore) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListGroup", ctx, entityID, groupIDs)
+	ret := m.ctrl.Call(m, "ListGroup", ctx, opt)
 	ret0, _ := ret[0].(types.GroupList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListGroup indicates an expected call of ListGroup.
-func (mr *MockDBStoreMockRecorder) ListGroup(ctx, entityID, groupIDs interface{}) *gomock.Call {
+func (mr *MockDBStoreMockRecorder) ListGroup(ctx, opt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockDBStore)(nil).ListGroup), ctx, entityID, groupIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroup", reflect.TypeOf((*MockDBStore)(nil).ListGroup), ctx, opt)
 }
 
 // ListRevision mocks base method.

--- a/internal/database/metadata/mysql/db.go
+++ b/internal/database/metadata/mysql/db.go
@@ -100,8 +100,8 @@ func (db *DB) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return sqlutil.GetGroupByName(ctx, db, name)
 }
 
-func (db *DB) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
-	return sqlutil.ListGroup(ctx, db, entityID, groupIDs)
+func (db *DB) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
+	return sqlutil.ListGroup(ctx, db, opt)
 }
 
 func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (int, error) {

--- a/internal/database/metadata/mysql/tx.go
+++ b/internal/database/metadata/mysql/tx.go
@@ -48,8 +48,8 @@ func (tx *Tx) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return sqlutil.GetGroupByName(ctx, tx, name)
 }
 
-func (tx *Tx) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
-	return sqlutil.ListGroup(ctx, tx, entityID, groupIDs)
+func (tx *Tx) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
+	return sqlutil.ListGroup(ctx, tx, opt)
 }
 
 func (tx *Tx) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) (int, error) {

--- a/internal/database/metadata/postgres/db.go
+++ b/internal/database/metadata/postgres/db.go
@@ -69,8 +69,8 @@ func (db *DB) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return sqlutil.GetGroupByName(ctx, db, name)
 }
 
-func (db *DB) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
-	return sqlutil.ListGroup(ctx, db, entityID, groupIDs)
+func (db *DB) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
+	return sqlutil.ListGroup(ctx, db, opt)
 }
 
 func (db *DB) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) (int, error) {

--- a/internal/database/metadata/postgres/tx.go
+++ b/internal/database/metadata/postgres/tx.go
@@ -48,8 +48,8 @@ func (tx *Tx) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return sqlutil.GetGroupByName(ctx, tx, name)
 }
 
-func (tx *Tx) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
-	return sqlutil.ListGroup(ctx, tx, entityID, groupIDs)
+func (tx *Tx) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
+	return sqlutil.ListGroup(ctx, tx, opt)
 }
 
 func (tx *Tx) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) (int, error) {

--- a/internal/database/metadata/sqlite/db.go
+++ b/internal/database/metadata/sqlite/db.go
@@ -90,8 +90,8 @@ func (db *DB) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return sqlutil.GetGroupByName(ctx, db, name)
 }
 
-func (db *DB) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
-	return sqlutil.ListGroup(ctx, db, entityID, groupIDs)
+func (db *DB) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
+	return sqlutil.ListGroup(ctx, db, opt)
 }
 
 func (db *DB) CreateRevision(ctx context.Context, opt metadata.CreateRevisionOpt) (int, error) {

--- a/internal/database/metadata/sqlite/tx.go
+++ b/internal/database/metadata/sqlite/tx.go
@@ -48,8 +48,8 @@ func (tx *Tx) GetGroupByName(ctx context.Context, name string) (*types.Group, er
 	return sqlutil.GetGroupByName(ctx, tx, name)
 }
 
-func (tx *Tx) ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error) {
-	return sqlutil.ListGroup(ctx, tx, entityID, groupIDs)
+func (tx *Tx) ListGroup(ctx context.Context, opt metadata.ListGroupOpt) (types.GroupList, error) {
+	return sqlutil.ListGroup(ctx, tx, opt)
 }
 
 func (tx *Tx) CreateFeature(ctx context.Context, opt metadata.CreateFeatureOpt) (int, error) {

--- a/internal/database/metadata/sqlutil/feature.go
+++ b/internal/database/metadata/sqlutil/feature.go
@@ -99,7 +99,9 @@ func ListFeature(ctx context.Context, sqlxCtx metadata.SqlxContext, opt metadata
 
 	// enrich group
 	groupIDs := features.GroupIDs()
-	groups, err := ListGroup(ctx, sqlxCtx, nil, &groupIDs)
+	groups, err := ListGroup(ctx, sqlxCtx, metadata.ListGroupOpt{
+		GroupIDs: &groupIDs,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/metadata/sqlutil/revision.go
+++ b/internal/database/metadata/sqlutil/revision.go
@@ -109,7 +109,9 @@ func ListRevision(ctx context.Context, sqlxCtx metadata.SqlxContext, groupID *in
 
 func enrichRevisions(ctx context.Context, sqlxCtx metadata.SqlxContext, revisions types.RevisionList) error {
 	groupIDs := revisions.GroupIDs()
-	groups, err := ListGroup(ctx, sqlxCtx, nil, &groupIDs)
+	groups, err := ListGroup(ctx, sqlxCtx, metadata.ListGroupOpt{
+		GroupIDs: &groupIDs,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/database/metadata/store.go
+++ b/internal/database/metadata/store.go
@@ -37,7 +37,7 @@ type DBStore interface {
 	UpdateGroup(ctx context.Context, opt UpdateGroupOpt) error
 	GetGroup(ctx context.Context, id int) (*types.Group, error)
 	GetGroupByName(ctx context.Context, name string) (*types.Group, error)
-	ListGroup(ctx context.Context, entityID *int, groupIDs *[]int) (types.GroupList, error)
+	ListGroup(ctx context.Context, opt ListGroupOpt) (types.GroupList, error)
 
 	// revision
 	CreateRevision(ctx context.Context, opt CreateRevisionOpt) (int, error)

--- a/internal/database/metadata/test_impl/group.go
+++ b/internal/database/metadata/test_impl/group.go
@@ -95,34 +95,62 @@ func TestListGroup(t *testing.T, prepareStore PrepareStoreFn, destroyStore Destr
 	_, err = store.CreateGroup(ctx, userBehaviorOpt)
 	require.NoError(t, err)
 
-	groups, err := store.ListGroup(ctx, nil, &[]int{})
+	groups, err := store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: nil,
+		GroupIDs:  &[]int{},
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(groups))
 
-	groups, err = store.ListGroup(ctx, &deviceGroupID, nil)
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: &[]int{deviceGroupID},
+		GroupIDs:  nil,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(groups))
 
-	groups, err = store.ListGroup(ctx, &userGroupID, nil)
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: &[]int{userGroupID},
+		GroupIDs:  nil,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(groups))
 
-	groups, err = store.ListGroup(ctx, nil, nil)
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: nil,
+		GroupIDs:  nil,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(groups))
 
-	groups, err = store.ListGroup(ctx, intPtr(0), nil)
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: &[]int{0},
+		GroupIDs:  nil,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(groups))
 
 	ids := []int{deviceGroupID, userGroupID}
-	groups, err = store.ListGroup(ctx, nil, &ids)
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: nil,
+		GroupIDs:  &ids,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(groups))
 
-	groups, err = store.ListGroup(ctx, &userEntityID, &ids)
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: &[]int{userEntityID},
+		GroupIDs:  &ids,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(groups))
+
+	groups, err = store.ListGroup(ctx, metadata.ListGroupOpt{
+		EntityIDs: &[]int{userEntityID, deviceEntityID},
+		GroupIDs:  nil,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(groups))
 }
 
 func TestCreateGroup(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyStoreFn) {

--- a/internal/database/metadata/types.go
+++ b/internal/database/metadata/types.go
@@ -66,6 +66,11 @@ type ListFeatureOpt struct {
 	FeatureIDs *[]int
 }
 
+type ListGroupOpt struct {
+	EntityIDs *[]int
+	GroupIDs  *[]int
+}
+
 type ListCachedFeatureOpt struct {
 	FullNames *[]string
 	GroupName *string

--- a/pkg/oomstore/group.go
+++ b/pkg/oomstore/group.go
@@ -40,7 +40,11 @@ func (s *OomStore) GetGroupByName(ctx context.Context, name string) (*types.Grou
 
 // ListGroup lists metadata of feature groups under the same entity.
 func (s *OomStore) ListGroup(ctx context.Context, entityID *int) (types.GroupList, error) {
-	return s.metadata.ListGroup(ctx, entityID, nil)
+	opt := metadata.ListGroupOpt{}
+	if entityID != nil {
+		opt.EntityIDs = &[]int{*entityID}
+	}
+	return s.metadata.ListGroup(ctx, opt)
 }
 
 // UpdateGroup updates metadata of a feature group.


### PR DESCRIPTION
This PR modifies the metadata method `ListGroup`: add argument `ListGroupOpt`, so that `ListGroup` could be used in more situations.