### PR TITLE
Refactor/online import

### DIFF
--- a/internal/database/offline/bigquery/export.go
+++ b/internal/database/offline/bigquery/export.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/oom-ai/oomstore/internal/database/dbutil"
-	"github.com/oom-ai/oomstore/internal/database/offline/sqlutil"
-	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/spf13/cast"
 	"google.golang.org/api/iterator"
 
+	"github.com/oom-ai/oomstore/internal/database/dbutil"
 	"github.com/oom-ai/oomstore/internal/database/offline"
+	"github.com/oom-ai/oomstore/internal/database/offline/sqlutil"
+	"github.com/oom-ai/oomstore/pkg/errdefs"
 	"github.com/oom-ai/oomstore/pkg/oomstore/types"
 )
 
@@ -30,17 +30,15 @@ func (db *DB) Export(ctx context.Context, opt offline.ExportOpt) (*types.ExportR
 
 func bigqueryQueryExportResults(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.ExportOpt, query string, args []interface{}, features types.FeatureList) (*types.ExportResult, error) {
 	stream := make(chan types.ExportRecord)
-	errs := make(chan error, 1) // at most 1 error
 	for _, arg := range args {
 		query = strings.Replace(query, "?", cast.ToString(arg), 1)
 	}
 
 	go func() {
 		defer close(stream)
-		defer close(errs)
 		rows, err := dbOpt.BigQueryDB.Query(query).Read(ctx)
 		if err != nil {
-			errs <- err
+			stream <- types.ExportRecord{Error: err}
 			return
 		}
 		for {
@@ -50,7 +48,7 @@ func bigqueryQueryExportResults(ctx context.Context, dbOpt dbutil.DBOpt, opt off
 				break
 			}
 			if err != nil {
-				errs <- errdefs.Errorf("failed at rows.Next, err=%v", err)
+				stream <- types.ExportRecord{Error: errdefs.Errorf("failed at rows.Next, err=%v", err)}
 				return
 			}
 			record := make([]interface{}, 0, len(recordMap))
@@ -58,9 +56,9 @@ func bigqueryQueryExportResults(ctx context.Context, dbOpt dbutil.DBOpt, opt off
 			for _, feature := range features {
 				record = append(record, recordMap[feature.DBFullName(Backend)])
 			}
-			stream <- record
+			stream <- types.ExportRecord{Record: record}
 		}
 	}()
 	header := append([]string{opt.EntityName}, features.FullNames()...)
-	return types.NewExportResult(header, stream, errs), nil
+	return types.NewExportResult(header, stream), nil
 }

--- a/internal/database/offline/test_impl/export.go
+++ b/internal/database/offline/test_impl/export.go
@@ -50,10 +50,9 @@ func TestExport(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyS
 	})
 
 	testCases := []struct {
-		description   string
-		opt           offline.ExportOpt
-		expected      [][]interface{}
-		expectedError error
+		description string
+		opt         offline.ExportOpt
+		expected    [][]interface{}
 	}{
 		{
 			description: "one group, batch features",
@@ -94,15 +93,11 @@ func TestExport(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyS
 			result, err := store.Export(ctx, tc.opt)
 			values := make([][]interface{}, 0)
 			for row := range result.Data {
-				values = append(values, row)
+				assert.NoError(t, row.Error)
+				values = append(values, row.Record)
 			}
-			if tc.expectedError != nil {
-				assert.EqualError(t, err, tc.expectedError.Error())
-			} else {
-				assert.ElementsMatch(t, tc.expected, values)
-				assert.NoError(t, err)
-				assert.NoError(t, result.CheckStreamError())
-			}
+			assert.ElementsMatch(t, tc.expected, values)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/internal/database/offline/test_impl/import.go
+++ b/internal/database/offline/test_impl/import.go
@@ -68,10 +68,10 @@ func TestImport(t *testing.T, prepareStore PrepareStoreFn, destroyStore DestroyS
 		})
 		records := make([][]interface{}, 0)
 		for row := range result.Data {
-			records = append(records, row)
+			assert.NoError(t, row.Error)
+			records = append(records, row.Record)
 		}
 		assert.NoError(t, err)
-		assert.NoError(t, result.CheckStreamError())
 		sort.Slice(records, func(i, j int) bool {
 			return cast.ToString(records[i][0]) < cast.ToString(records[j][0])
 		})

--- a/internal/database/offline/test_impl/snapshot.go
+++ b/internal/database/offline/test_impl/snapshot.go
@@ -61,7 +61,8 @@ func TestSnapshot(t *testing.T, prepareStore PrepareStoreFn, destroyStore Destro
 	})
 	values := make([][]interface{}, 0)
 	for row := range result.Data {
-		values = append(values, row)
+		assert.NoError(t, err)
+		values = append(values, row.Record)
 	}
 	sort.Slice(values, func(i, j int) bool {
 		return cast.ToInt64(values[i][0]) < cast.ToInt64(values[j][0])
@@ -73,6 +74,5 @@ func TestSnapshot(t *testing.T, prepareStore PrepareStoreFn, destroyStore Destro
 		{"1237", "pixel", int64(200), int64(11)},
 	}
 	assert.Equal(t, expected, values)
-	assert.NoError(t, result.CheckStreamError())
 	assert.NoError(t, err)
 }

--- a/internal/database/online/dynamodb/import.go
+++ b/internal/database/online/dynamodb/import.go
@@ -46,6 +46,10 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 	// Step 2: import items to the table
 	items := make([]types.WriteRequest, 0, BatchWriteItemCapacity)
 	for record := range opt.ExportStream {
+		if record.Error != nil {
+			return record.Error
+		}
+
 		item, err := buildItem(record, opt)
 		if err != nil {
 			return err
@@ -66,14 +70,6 @@ func (db *DB) Import(ctx context.Context, opt online.ImportOpt) error {
 		return err
 	}
 
-	if opt.ExportError != nil {
-		select {
-		case err := <-opt.ExportError:
-			return err
-		default:
-			return nil
-		}
-	}
 	return nil
 }
 

--- a/internal/database/online/test_impl/util.go
+++ b/internal/database/online/test_impl/util.go
@@ -83,16 +83,22 @@ func init() {
 			Group:   &group1,
 		},
 		Data: []types.ExportRecord{
-			[]interface{}{"3215", int64(18), "F", 1.1, true, time.Now()},
-			[]interface{}{"3216", int64(29), nil, 2.0, false, time.Now()},
-			[]interface{}{"3217", int64(44), "M", 3.1, true, time.Now()},
+			{
+				Record: []interface{}{"3215", int64(18), "F", 1.1, true, time.Now()},
+			},
+			{
+				Record: []interface{}{"3216", int64(29), nil, 2.0, false, time.Now()},
+			},
+			{
+				Record: []interface{}{"3217", int64(44), "M", 3.1, true, time.Now()},
+			},
 		},
 	}
 
 	var data []types.ExportRecord
 	for i := 0; i < 100; i++ {
 		record := []interface{}{dbutil.RandString(10), rand.Float64()}
-		data = append(data, record)
+		data = append(data, types.ExportRecord{Record: record, Error: nil})
 	}
 	SampleMedium = Sample{
 		Entity: entity,
@@ -134,10 +140,18 @@ func init() {
 			},
 		},
 		Data: []types.ExportRecord{
-			[]interface{}{"3215", int64(1), "1,2,3,4"},
-			[]interface{}{"3216", int64(2), "2,3,4,5"},
-			[]interface{}{"3217", int64(3), "3,4,5,6"},
-			[]interface{}{"3218", int64(4), "4,5,6,7"},
+			{
+				Record: []interface{}{"3215", int64(1), "1,2,3,4"},
+			},
+			{
+				Record: []interface{}{"3216", int64(2), "2,3,4,5"},
+			},
+			{
+				Record: []interface{}{"3217", int64(3), "3,4,5,6"},
+			},
+			{
+				Record: []interface{}{"3218", int64(4), "4,5,6,7"},
+			},
 		},
 	}
 }

--- a/internal/database/online/types.go
+++ b/internal/database/online/types.go
@@ -41,7 +41,6 @@ type ImportOpt struct {
 	Group        types.Group
 	Features     types.FeatureList
 	ExportStream <-chan types.ExportRecord
-	ExportError  <-chan error
 	RevisionID   *int
 }
 

--- a/oomagent/server.go
+++ b/oomagent/server.go
@@ -311,7 +311,11 @@ func (s *server) ChannelExport(req *codegen.ChannelExportRequest, stream codegen
 
 	header := exportResult.Header
 	for row := range exportResult.Data {
-		valueRow, err := convertToValueSlice(row)
+		if row.Error != nil {
+			return row.Error
+		}
+
+		valueRow, err := convertToValueSlice(row.Record)
 		if err != nil {
 			return internalError(err.Error())
 		}
@@ -323,9 +327,6 @@ func (s *server) ChannelExport(req *codegen.ChannelExportRequest, stream codegen
 		}
 		// Only need to send header upon the first response
 		header = nil
-	}
-	if err := exportResult.CheckStreamError(); err != nil {
-		return internalError(err.Error())
 	}
 	return nil
 }

--- a/oomcli/cmd/export_helper.go
+++ b/oomcli/cmd/export_helper.go
@@ -45,11 +45,15 @@ func printExportResultInCSV(exportResult *types.ExportResult) error {
 	}
 
 	for row := range exportResult.Data {
-		if err := w.Write(cast.ToStringSlice([]interface{}(row))); err != nil {
+		if row.Error != nil {
+			return row.Error
+		}
+
+		if err := w.Write(cast.ToStringSlice([]interface{}(row.Record))); err != nil {
 			return err
 		}
 	}
-	return exportResult.CheckStreamError()
+	return nil
 }
 
 func printExportResultInASCIITable(exportResult *types.ExportResult) error {
@@ -58,9 +62,13 @@ func printExportResultInASCIITable(exportResult *types.ExportResult) error {
 	table.SetAutoFormatHeaders(false)
 
 	for row := range exportResult.Data {
-		table.Append(cast.ToStringSlice([]interface{}(row)))
+		if row.Error != nil {
+			return row.Error
+		}
+
+		table.Append(cast.ToStringSlice([]interface{}(row.Record)))
 	}
 
 	table.Render()
-	return exportResult.CheckStreamError()
+	return nil
 }

--- a/pkg/oomstore/export.go
+++ b/pkg/oomstore/export.go
@@ -120,9 +120,13 @@ func (s *OomStore) Export(ctx context.Context, opt types.ExportOpt) error {
 		return err
 	}
 	for row := range exportResult.Data {
-		if err := w.Write(cast.ToStringSlice([]interface{}(row))); err != nil {
+		if row.Error != nil {
+			return row.Error
+		}
+
+		if err := w.Write(cast.ToStringSlice([]interface{}(row.Record))); err != nil {
 			return err
 		}
 	}
-	return exportResult.CheckStreamError()
+	return nil
 }

--- a/pkg/oomstore/sync.go
+++ b/pkg/oomstore/sync.go
@@ -56,7 +56,6 @@ func (s *OomStore) syncBatch(ctx context.Context, opt types.SyncOpt, group *type
 		Group:        *group,
 		Features:     features,
 		ExportStream: exportResult.Data,
-		ExportError:  exportResult.GetErrorChannel(),
 		RevisionID:   &revision.ID,
 	}); err != nil {
 		return err
@@ -118,7 +117,6 @@ func (s *OomStore) syncStream(ctx context.Context, opt types.SyncOpt) error {
 		Group:        *group,
 		Features:     features,
 		ExportStream: exportResult.Data,
-		ExportError:  exportResult.GetErrorChannel(),
 	})
 }
 

--- a/pkg/oomstore/types/types.go
+++ b/pkg/oomstore/types/types.go
@@ -15,14 +15,17 @@ const (
 	TableStreamCdc      TableType = "stream_cdc"
 )
 
-type ExportRecord []interface{}
+type ExportRecord struct {
+	Record []interface{}
+	Error  error
+}
 
 func (r ExportRecord) EntityKey() string {
-	return r[0].(string)
+	return r.Record[0].(string)
 }
 
 func (r ExportRecord) ValueAt(i int) interface{} {
-	return r[i+1]
+	return r.Record[i+1]
 }
 
 type EntityRow struct {
@@ -40,31 +43,13 @@ type JoinResult struct {
 type ExportResult struct {
 	Header []string
 	Data   <-chan ExportRecord
-	error  <-chan error
 }
 
-func NewExportResult(header []string, data <-chan ExportRecord, error <-chan error) *ExportResult {
+func NewExportResult(header []string, data <-chan ExportRecord) *ExportResult {
 	return &ExportResult{
 		Header: header,
 		Data:   data,
-		error:  error,
 	}
-}
-
-// ATTENTION: call this method only after you consume all elements
-// from Data channel; otherwise, it will block the Data channel.
-func (e *ExportResult) CheckStreamError() error {
-	if e == nil {
-		return nil
-	}
-	if e.error != nil {
-		return <-e.error
-	}
-	return nil
-}
-
-func (e *ExportResult) GetErrorChannel() <-chan error {
-	return e.error
 }
 
 type DataTableTimeRange struct {


### PR DESCRIPTION
this PR does:
1. `types.ExportRecord` add new field `Error error`
2. `types.ExportResult` remove field `error <- error`

fix #1146 

note: This PR is just one way to do it, and whether or not to do it is up for discussion.
