### PR TITLE
Jinghan/reuse offline method `CreateTable` in `Snapshot` method

### DIFF
--- a/internal/database/offline/sqlutil/create_table.go
+++ b/internal/database/offline/sqlutil/create_table.go
@@ -11,7 +11,7 @@ import (
 
 func CreateTable(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.CreateTableOpt) error {
 	if !supportIndex(dbOpt.Backend) {
-		return CreateTableNoIndex(ctx, dbOpt, opt)
+		return createTableNoIndex(ctx, dbOpt, opt)
 	}
 	switch opt.TableType {
 	case types.TableBatchSnapshot:
@@ -45,7 +45,7 @@ func CreateTable(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.CreateTabl
 	return nil
 }
 
-func CreateTableNoIndex(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.CreateTableOpt) error {
+func createTableNoIndex(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.CreateTableOpt) error {
 	var hasUnixMilli bool
 	switch opt.TableType {
 	case types.TableBatchSnapshot:

--- a/internal/database/offline/sqlutil/snapshot.go
+++ b/internal/database/offline/sqlutil/snapshot.go
@@ -71,8 +71,12 @@ func Snapshot(ctx context.Context, dbOpt dbutil.DBOpt, opt offline.SnapshotOpt) 
 		currCdcTableName = fmt.Sprintf("%s.%s", *dbOpt.DatasetID, currCdcTableName)
 	}
 
-	schema := dbutil.BuildTableSchema(currSnapshotTableName, opt.Group.Entity.Name, true, opt.Features, []string{opt.Group.Entity.Name}, dbOpt.Backend)
-	if err := dbOpt.ExecContext(ctx, schema, nil); err != nil {
+	if err := CreateTable(ctx, dbOpt, offline.CreateTableOpt{
+		TableName:  currSnapshotTableName,
+		EntityName: opt.Group.Entity.Name,
+		Features:   opt.Features,
+		TableType:  types.TableStreamSnapshot,
+	}); err != nil {
 		return err
 	}
 	query, err := buildSnapshotQuery(snapshotQueryParams{


### PR DESCRIPTION
This PR refactors offline method `Snapshot`: reuse method `CreateTable` to simplify the logic.