### PR TITLE
refactor(oomagent|oomcli): replace ioutil.ReadFile with os.ReadFile

### DIFF
--- a/oomagent/root.go
+++ b/oomagent/root.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -102,7 +101,7 @@ func initConfig() {
 	if envCfgFile := os.Getenv("OOMAGENT_CONFIG"); envCfgFile != "" {
 		cfgFile = envCfgFile
 	}
-	cfgContent, err := ioutil.ReadFile(filepath.Clean(cfgFile))
+	cfgContent, err := os.ReadFile(filepath.Clean(cfgFile))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed reading config file: %v\n", err)
 		os.Exit(1)

--- a/oomcli/cmd/root.go
+++ b/oomcli/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -52,7 +51,7 @@ func initConfig() {
 	if envCfgFile := os.Getenv("OOMCLI_CONFIG"); envCfgFile != "" {
 		cfgFile = envCfgFile
 	}
-	cfgContent, err := ioutil.ReadFile(filepath.Clean(cfgFile))
+	cfgContent, err := os.ReadFile(filepath.Clean(cfgFile))
 	if err != nil {
 		exitf("failed reading config file: %v\n", err)
 	}


### PR DESCRIPTION
the package `io/ioutil` will be deprecated, see: https://github.com/go-critic/go-critic/issues/1019